### PR TITLE
Add tented vias

### DIFF
--- a/padstacks/via-round-bottom-tented.json
+++ b/padstacks/via-round-bottom-tented.json
@@ -1,0 +1,101 @@
+{
+    "holes": {
+        "056fa8e5-8b21-454e-a805-467fd49763b6": {
+            "diameter": 400000,
+            "length": 500000,
+            "parameter_class": "hole",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            },
+            "plated": true,
+            "shape": "round"
+        }
+    },
+    "name": "Circular via (bottom tented)",
+    "padstack_type": "via",
+    "parameter_program": "get-parameter [ via_diameter ]\nset-shape [ via circle ]\n\nget-parameter [ hole_diameter ]\ndup\nset-hole [ hole round ]\n\nget-parameter [ via_solder_mask_expansion ] 2 *\n+\nset-shape [ mask circle ]",
+    "parameter_set": {
+        "hole_diameter": 400000,
+        "via_diameter": 700000,
+        "via_solder_mask_expansion": 100000
+    },
+    "parameters_required": [
+        "hole_diameter",
+        "via_diameter"
+    ],
+    "polygons": {},
+    "shapes": {
+        "1919564e-4dfd-4afa-ae6b-b06ddcefb9e6": {
+            "form": "circle",
+            "layer": 10,
+            "parameter_class": "mask",
+            "params": [
+                600000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "3d4a1caa-13a9-4828-aee6-4ec776b4f007": {
+            "form": "circle",
+            "layer": -1,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "587492a5-d20b-4258-b1a8-04da900ea393": {
+            "form": "circle",
+            "layer": -100,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "c0afc6ea-f577-42ee-8860-16eaf52721bf": {
+            "form": "circle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        }
+    },
+    "type": "padstack",
+    "uuid": "42b89a10-6869-4143-8bd8-5cb157b00f5b",
+    "well_known_name": ""
+}

--- a/padstacks/via-round-tented.json
+++ b/padstacks/via-round-tented.json
@@ -1,0 +1,84 @@
+{
+    "holes": {
+        "056fa8e5-8b21-454e-a805-467fd49763b6": {
+            "diameter": 400000,
+            "length": 500000,
+            "parameter_class": "hole",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            },
+            "plated": true,
+            "shape": "round"
+        }
+    },
+    "name": "Circular via (tented)",
+    "padstack_type": "via",
+    "parameter_program": "get-parameter [ via_diameter ]\nset-shape [ via circle ]\n\nget-parameter [ hole_diameter ]\nset-hole [ hole round ]\n",
+    "parameter_set": {
+        "hole_diameter": 400000,
+        "via_diameter": 700000
+    },
+    "parameters_required": [
+        "hole_diameter",
+        "via_diameter"
+    ],
+    "polygons": {},
+    "shapes": {
+        "3d4a1caa-13a9-4828-aee6-4ec776b4f007": {
+            "form": "circle",
+            "layer": -1,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "587492a5-d20b-4258-b1a8-04da900ea393": {
+            "form": "circle",
+            "layer": -100,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "c0afc6ea-f577-42ee-8860-16eaf52721bf": {
+            "form": "circle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        }
+    },
+    "type": "padstack",
+    "uuid": "8b6dee4b-af88-4c0f-b38b-c5364649e65e",
+    "well_known_name": ""
+}

--- a/padstacks/via-round-top-tented.json
+++ b/padstacks/via-round-top-tented.json
@@ -1,0 +1,101 @@
+{
+    "holes": {
+        "056fa8e5-8b21-454e-a805-467fd49763b6": {
+            "diameter": 400000,
+            "length": 500000,
+            "parameter_class": "hole",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            },
+            "plated": true,
+            "shape": "round"
+        }
+    },
+    "name": "Circular via (top tented)",
+    "padstack_type": "via",
+    "parameter_program": "get-parameter [ via_diameter ]\nset-shape [ via circle ]\n\nget-parameter [ hole_diameter ]\ndup\nset-hole [ hole round ]\n\nget-parameter [ via_solder_mask_expansion ] 2 *\n+\nset-shape [ mask circle ]",
+    "parameter_set": {
+        "hole_diameter": 400000,
+        "via_diameter": 700000,
+        "via_solder_mask_expansion": 100000
+    },
+    "parameters_required": [
+        "hole_diameter",
+        "via_diameter"
+    ],
+    "polygons": {},
+    "shapes": {
+        "0fcc5be3-fa35-464c-ac89-7bfaea0821da": {
+            "form": "circle",
+            "layer": -110,
+            "parameter_class": "mask",
+            "params": [
+                600000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "3d4a1caa-13a9-4828-aee6-4ec776b4f007": {
+            "form": "circle",
+            "layer": -1,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "587492a5-d20b-4258-b1a8-04da900ea393": {
+            "form": "circle",
+            "layer": -100,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "c0afc6ea-f577-42ee-8860-16eaf52721bf": {
+            "form": "circle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                700000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        }
+    },
+    "type": "padstack",
+    "uuid": "c9e51773-f8d7-44f2-8641-cdf630f56e72",
+    "well_known_name": ""
+}

--- a/padstacks/via-square-bottom-tented.json
+++ b/padstacks/via-square-bottom-tented.json
@@ -1,0 +1,122 @@
+{
+    "holes": {
+        "2d11f3c8-49d0-49ca-bc28-3027cf189f14": {
+            "diameter": 400000,
+            "length": 500000,
+            "parameter_class": "hole",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            },
+            "plated": true,
+            "shape": "round"
+        }
+    },
+    "name": "Square Via (bottom tented)",
+    "padstack_type": "via",
+    "parameter_program": "get-parameter [ via_diameter ] 7 * 10 / dup\nset-shape [ via rectangle ]\n\nget-parameter [ hole_diameter ]\ndup\nset-hole [ hole round ]\n\nget-parameter [ via_solder_mask_expansion ]\n+ dup\nset-shape [ mask rectangle ]",
+    "parameter_set": {
+        "hole_diameter": 400000,
+        "via_diameter": 800000,
+        "via_solder_mask_expansion": 100000
+    },
+    "parameters_required": [
+        "hole_diameter",
+        "via_diameter"
+    ],
+    "polygons": {},
+    "shapes": {
+        "0e2f322a-682e-4237-bc01-fd95868edd2a": {
+            "form": "rectangle",
+            "layer": -1,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "34930f1c-28ae-4e53-b721-4a31045df004": {
+            "form": "rectangle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "3d111434-e21a-4b29-84cc-91457e475470": {
+            "form": "rectangle",
+            "layer": -100,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "4278c1c7-a716-46ed-bba5-af45d2cc652b": {
+            "form": "rectangle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "91abaa8e-ae47-4fe6-b345-27a332180134": {
+            "form": "rectangle",
+            "layer": 10,
+            "parameter_class": "mask",
+            "params": [
+                500000,
+                500000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        }
+    },
+    "type": "padstack",
+    "uuid": "f48305e7-9b1e-4801-9aa9-8d8d23196b5e",
+    "well_known_name": ""
+}

--- a/padstacks/via-square-tented.json
+++ b/padstacks/via-square-tented.json
@@ -1,0 +1,104 @@
+{
+    "holes": {
+        "2d11f3c8-49d0-49ca-bc28-3027cf189f14": {
+            "diameter": 400000,
+            "length": 500000,
+            "parameter_class": "hole",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            },
+            "plated": true,
+            "shape": "round"
+        }
+    },
+    "name": "Square Via (tented)",
+    "padstack_type": "via",
+    "parameter_program": "get-parameter [ via_diameter ] 7 * 10 / dup\nset-shape [ via rectangle ]\n\nget-parameter [ hole_diameter ]\nset-hole [ hole round ]\n",
+    "parameter_set": {
+        "hole_diameter": 400000,
+        "via_diameter": 800000
+    },
+    "parameters_required": [
+        "hole_diameter",
+        "via_diameter"
+    ],
+    "polygons": {},
+    "shapes": {
+        "0e2f322a-682e-4237-bc01-fd95868edd2a": {
+            "form": "rectangle",
+            "layer": -1,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "34930f1c-28ae-4e53-b721-4a31045df004": {
+            "form": "rectangle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "3d111434-e21a-4b29-84cc-91457e475470": {
+            "form": "rectangle",
+            "layer": -100,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "4278c1c7-a716-46ed-bba5-af45d2cc652b": {
+            "form": "rectangle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        }
+    },
+    "type": "padstack",
+    "uuid": "eb40d499-94ff-422d-bed6-358b57bba8ee",
+    "well_known_name": ""
+}

--- a/padstacks/via-square-top-tented.json
+++ b/padstacks/via-square-top-tented.json
@@ -1,0 +1,122 @@
+{
+    "holes": {
+        "2d11f3c8-49d0-49ca-bc28-3027cf189f14": {
+            "diameter": 400000,
+            "length": 500000,
+            "parameter_class": "hole",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            },
+            "plated": true,
+            "shape": "round"
+        }
+    },
+    "name": "Square Via (top tented)",
+    "padstack_type": "via",
+    "parameter_program": "get-parameter [ via_diameter ] 7 * 10 / dup\nset-shape [ via rectangle ]\n\nget-parameter [ hole_diameter ]\ndup\nset-hole [ hole round ]\n\nget-parameter [ via_solder_mask_expansion ]\n+ dup\nset-shape [ mask rectangle ]",
+    "parameter_set": {
+        "hole_diameter": 400000,
+        "via_diameter": 800000,
+        "via_solder_mask_expansion": 100000
+    },
+    "parameters_required": [
+        "hole_diameter",
+        "via_diameter"
+    ],
+    "polygons": {},
+    "shapes": {
+        "0e2f322a-682e-4237-bc01-fd95868edd2a": {
+            "form": "rectangle",
+            "layer": -1,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "34930f1c-28ae-4e53-b721-4a31045df004": {
+            "form": "rectangle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "3d111434-e21a-4b29-84cc-91457e475470": {
+            "form": "rectangle",
+            "layer": -100,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "4278c1c7-a716-46ed-bba5-af45d2cc652b": {
+            "form": "rectangle",
+            "layer": 0,
+            "parameter_class": "via",
+            "params": [
+                560000,
+                560000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "4c9c21d8-8952-4ed8-8ae7-15249ec5d972": {
+            "form": "rectangle",
+            "layer": -110,
+            "parameter_class": "mask",
+            "params": [
+                500000,
+                500000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        }
+    },
+    "type": "padstack",
+    "uuid": "0f536cb8-390a-4a05-8039-c5b65461fc0d",
+    "well_known_name": ""
+}


### PR DESCRIPTION
This PR adds both circular and square tented via padstacks. I also added variants where only one PCB side is tented.