### PR TITLE
Added 2N390x transistors

### DIFF
--- a/parts/transistor/2N390x/2N3904.json
+++ b/parts/transistor/2N390x/2N3904.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N3904"
+    ],
+    "base": "08f3cf2e-0b8b-49d6-a389-e0ed67292afd",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N3903-D.PDF"
+    ],
+    "description": [
+        true,
+        "General Purpose NPN Transistor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N3903-D.PDF"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "6f7f6c0e-b2e8-42b5-a2c3-6ba12b418345",
+    "value": [
+        false,
+        "2N3904"
+    ]
+}

--- a/parts/transistor/2N390x/2N3904G.json
+++ b/parts/transistor/2N390x/2N3904G.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N3904G"
+    ],
+    "base": "08f3cf2e-0b8b-49d6-a389-e0ed67292afd",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N3903-D.PDF"
+    ],
+    "description": [
+        true,
+        "General Purpose NPN Transistor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N3903-D.PDF"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "355230d3-3005-4f24-8213-fdc9c9e9ac0a",
+    "value": [
+        true,
+        "2N3904"
+    ]
+}

--- a/parts/transistor/2N390x/2N3904_base.json
+++ b/parts/transistor/2N390x/2N3904_base.json
@@ -1,0 +1,49 @@
+{
+    "MPN": [
+        false,
+        "2N3904 (Base)"
+    ],
+    "datasheet": [
+        false,
+        "https://www.onsemi.com/pub/Collateral/2N3903-D.PDF"
+    ],
+    "description": [
+        false,
+        "General Purpose NPN Transistor"
+    ],
+    "entity": "15e94b7a-b7c9-4bf2-820c-11074dc0718e",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "https://www.onsemi.com/pub/Collateral/2N3903-D.PDF"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "f94aec49-d6bf-4170-8d54-ba567cd9c9ea",
+    "pad_map": {
+        "0c65f99f-5e80-482c-abf3-5a46acfd1174": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "eb63ac9a-5d7e-42e2-92ea-a140a97f47d0"
+        },
+        "2857d642-7cf6-4eb9-8741-6249df6c8cab": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "4887ef47-94f0-4fd1-b552-c424bd37a3e7"
+        },
+        "5d851f2d-3f8d-4732-b7e2-5a1c7eae2766": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "074c3718-08fd-4f94-88fc-2bb43174b245"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "npn",
+        "to-92",
+        "transistor"
+    ],
+    "type": "part",
+    "uuid": "08f3cf2e-0b8b-49d6-a389-e0ed67292afd",
+    "value": [
+        false,
+        "2N3904"
+    ]
+}

--- a/parts/transistor/2N390x/2N3906.json
+++ b/parts/transistor/2N390x/2N3906.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N3906"
+    ],
+    "base": "392abecc-5c13-452d-ba7c-a2c2815c0f38",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N3906-D.PDF"
+    ],
+    "description": [
+        true,
+        "General Purpose PNP Transistor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "fc99dd80-1cf9-47c6-a842-68c657a0c2e5",
+    "value": [
+        true,
+        "2N3906"
+    ]
+}

--- a/parts/transistor/2N390x/2N3906G.json
+++ b/parts/transistor/2N390x/2N3906G.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N3906G"
+    ],
+    "base": "392abecc-5c13-452d-ba7c-a2c2815c0f38",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N3906-D.PDF"
+    ],
+    "description": [
+        true,
+        "General Purpose PNP Transistor"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "bd8a380e-957d-42a5-8c71-4522e4c066e9",
+    "value": [
+        false,
+        "2N3906"
+    ]
+}

--- a/parts/transistor/2N390x/2N3906_base.json
+++ b/parts/transistor/2N390x/2N3906_base.json
@@ -1,0 +1,49 @@
+{
+    "MPN": [
+        false,
+        "2N3906 (Base)"
+    ],
+    "datasheet": [
+        false,
+        "https://www.onsemi.com/pub/Collateral/2N3906-D.PDF"
+    ],
+    "description": [
+        false,
+        "General Purpose PNP Transistor"
+    ],
+    "entity": "f2443156-b218-4979-b244-20ef0bf2476a",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "f94aec49-d6bf-4170-8d54-ba567cd9c9ea",
+    "pad_map": {
+        "0c65f99f-5e80-482c-abf3-5a46acfd1174": {
+            "gate": "40ce877c-ec96-4b42-acad-4860f7587fd1",
+            "pin": "6bd7bb7b-95c6-4ed4-9a71-55f5e3b72a92"
+        },
+        "2857d642-7cf6-4eb9-8741-6249df6c8cab": {
+            "gate": "40ce877c-ec96-4b42-acad-4860f7587fd1",
+            "pin": "7c4ac8a6-e267-48cd-89d5-28ed30de088a"
+        },
+        "5d851f2d-3f8d-4732-b7e2-5a1c7eae2766": {
+            "gate": "40ce877c-ec96-4b42-acad-4860f7587fd1",
+            "pin": "f915c514-c206-40fc-8a4a-46a259d4f80e"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "pnp",
+        "to-92",
+        "transistor"
+    ],
+    "type": "part",
+    "uuid": "392abecc-5c13-452d-ba7c-a2c2815c0f38",
+    "value": [
+        false,
+        "2N3906"
+    ]
+}


### PR DESCRIPTION
Added the through-hole transistors by onsemi:
- 2N3904
- 2N3904G
- 2N3906
- 2N3906G

Datasheets:
https://www.onsemi.com/pub/Collateral/2N3906-D.PDF
https://www.onsemi.com/pub/Collateral/2N3903-D.PDF
