### PR TITLE
Added CD40106B Hex Inverters

### DIFF
--- a/parts/ic/logic/ti/CD40106B/CD40106BE.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BE.json
@@ -1,0 +1,95 @@
+{
+    "MPN": [
+        false,
+        "CD40106BE"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        false,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "entity": "a30d5839-0769-490e-a7ba-6bf1b24ce6ca",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "07e2d21f-ce33-4c58-9d56-6b2dce0e6919",
+    "pad_map": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "gate": "9e96838e-1bc3-4476-9af8-758580d7bebf",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "gate": "fb7423db-fcf6-4898-a7fb-42ca3b2830fd",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "dee5dca1-1943-40ee-912d-82520cc7b584",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "gate": "7098d4b8-771d-4cb6-a517-e7bf7d915531",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "3805ca0e-233b-495c-91a6-271a60ddbefe",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "dee5dca1-1943-40ee-912d-82520cc7b584",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "gate": "18277f87-68d5-423d-93c5-0f63f37aabfd",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "7098d4b8-771d-4cb6-a517-e7bf7d915531",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "fb7423db-fcf6-4898-a7fb-42ca3b2830fd",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "22450bcf-a6a2-4dbc-a8b4-cfffe962be7b",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "3805ca0e-233b-495c-91a6-271a60ddbefe",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "gate": "18277f87-68d5-423d-93c5-0f63f37aabfd",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "gate": "9e96838e-1bc3-4476-9af8-758580d7bebf",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "22450bcf-a6a2-4dbc-a8b4-cfffe962be7b",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "cmos",
+        "dip-14",
+        "ic",
+        "inverter",
+        "schmitt-trigger"
+    ],
+    "type": "part",
+    "uuid": "e5366c1c-0d09-48b1-a575-72c1b68cc18b",
+    "value": [
+        false,
+        "CD40106BE"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CD40106BM.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BM.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD40106BM"
+    ],
+    "base": "b7b14046-dd90-4cbc-9bb4-d8ddc8a32c17",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "2320d875-28a3-4c8a-a5df-c72ff110a1b7",
+    "value": [
+        true,
+        "CD40106BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CD40106BM96.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BM96.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD40106BM96"
+    ],
+    "base": "b7b14046-dd90-4cbc-9bb4-d8ddc8a32c17",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "4af8b8bc-13b5-4f68-adc6-cdd77821387c",
+    "value": [
+        true,
+        "CD40106BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CD40106BM96E4.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BM96E4.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD40106BM96E4"
+    ],
+    "base": "b7b14046-dd90-4cbc-9bb4-d8ddc8a32c17",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "99c9020c-e344-4cfb-94fa-27000cb572a0",
+    "value": [
+        true,
+        "CD40106BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CD40106BM96G4.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BM96G4.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD40106BM96G4"
+    ],
+    "base": "b7b14046-dd90-4cbc-9bb4-d8ddc8a32c17",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "2e89d65b-644a-4a52-ae64-b16483a32e8e",
+    "value": [
+        true,
+        "CD40106BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CD40106BMG4.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BMG4.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD40106BMG4"
+    ],
+    "base": "b7b14046-dd90-4cbc-9bb4-d8ddc8a32c17",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "4b191323-c7db-4edf-8180-8345d1f89b64",
+    "value": [
+        true,
+        "CD40106BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CD40106BMT.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BMT.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD40106BMT"
+    ],
+    "base": "b7b14046-dd90-4cbc-9bb4-d8ddc8a32c17",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "417b695b-cd1e-4a46-9c96-59c0eb2fbe54",
+    "value": [
+        true,
+        "CD40106BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CD40106BM_Base.json
+++ b/parts/ic/logic/ti/CD40106B/CD40106BM_Base.json
@@ -1,0 +1,95 @@
+{
+    "MPN": [
+        false,
+        "CD40106BM (Base Part)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        false,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "entity": "a30d5839-0769-490e-a7ba-6bf1b24ce6ca",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "14aeb235-3edc-4327-9a25-7de5a4bd6808",
+    "pad_map": {
+        "150ac7fa-7f46-49f2-ab10-8c0f447d0bd4": {
+            "gate": "dee5dca1-1943-40ee-912d-82520cc7b584",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "29845fb8-d37b-4a23-a456-3897cba0240e": {
+            "gate": "22450bcf-a6a2-4dbc-a8b4-cfffe962be7b",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "32350e73-3524-4259-aad9-74a372ee42e5": {
+            "gate": "18277f87-68d5-423d-93c5-0f63f37aabfd",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "327e4032-c988-4b9b-8944-cd6e4257ca8e": {
+            "gate": "3805ca0e-233b-495c-91a6-271a60ddbefe",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "38f25dfc-b2f4-4515-83fb-f63c0c529fc9": {
+            "gate": "fb7423db-fcf6-4898-a7fb-42ca3b2830fd",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "6de88445-a438-452d-9a56-ca754d9c97f8": {
+            "gate": "18277f87-68d5-423d-93c5-0f63f37aabfd",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "71284ebf-b339-4f0d-bd5f-765d1eb04896": {
+            "gate": "dee5dca1-1943-40ee-912d-82520cc7b584",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "7d774933-233f-42d6-aa61-645fccad511f": {
+            "gate": "9e96838e-1bc3-4476-9af8-758580d7bebf",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "7e3e50d4-f9a5-4b8d-80bb-9c119b9c88ed": {
+            "gate": "22450bcf-a6a2-4dbc-a8b4-cfffe962be7b",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "8a7ba3f8-c2ff-4736-a7af-63bc6b28775a": {
+            "gate": "7098d4b8-771d-4cb6-a517-e7bf7d915531",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "ce8e0ff3-c8cb-430b-b47d-4f16d58bb7f3": {
+            "gate": "9e96838e-1bc3-4476-9af8-758580d7bebf",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "cf3a38df-5ed7-47dd-84ce-0f9d0a0ba9d1": {
+            "gate": "3805ca0e-233b-495c-91a6-271a60ddbefe",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "d86bca97-5554-479a-8512-843a86f676e5": {
+            "gate": "7098d4b8-771d-4cb6-a517-e7bf7d915531",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "dd326f38-d93c-4563-a442-d5334a8426d3": {
+            "gate": "fb7423db-fcf6-4898-a7fb-42ca3b2830fd",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "cmos",
+        "ic",
+        "inverter",
+        "schmitt-trigger",
+        "soic-14"
+    ],
+    "type": "part",
+    "uuid": "b7b14046-dd90-4cbc-9bb4-d8ddc8a32c17",
+    "value": [
+        false,
+        "CD40106BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD40106B/CM0106B.json
+++ b/parts/ic/logic/ti/CD40106B/CM0106B.json
@@ -1,0 +1,95 @@
+{
+    "MPN": [
+        false,
+        "CM0106B"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/cd40106b.pdf"
+    ],
+    "description": [
+        false,
+        "CMOS Hex Schmitt-Trigger Inverters"
+    ],
+    "entity": "a30d5839-0769-490e-a7ba-6bf1b24ce6ca",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "12001aad-23c9-46d2-bfdb-75ffd2479776",
+    "pad_map": {
+        "261fe7ff-1e20-45bc-b96f-0733c16960c4": {
+            "gate": "dee5dca1-1943-40ee-912d-82520cc7b584",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "427439e3-355e-4c65-a502-338cba5d0f4b": {
+            "gate": "9e96838e-1bc3-4476-9af8-758580d7bebf",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "46ab3d42-b140-4167-939f-00bebcccfc22": {
+            "gate": "fb7423db-fcf6-4898-a7fb-42ca3b2830fd",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "48201ebb-e791-4c91-9bdb-fc069831ade8": {
+            "gate": "18277f87-68d5-423d-93c5-0f63f37aabfd",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "5ea90398-774b-43ec-bd14-db28ef507b64": {
+            "gate": "7098d4b8-771d-4cb6-a517-e7bf7d915531",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "64731022-0d14-4c0a-996c-3eed9f417c00": {
+            "gate": "3805ca0e-233b-495c-91a6-271a60ddbefe",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "6e7efadb-0a82-4a26-8965-513d6ff56219": {
+            "gate": "22450bcf-a6a2-4dbc-a8b4-cfffe962be7b",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "af643901-6c38-4b1b-b30c-371212d093f7": {
+            "gate": "7098d4b8-771d-4cb6-a517-e7bf7d915531",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "b37a46a0-e07e-45ef-87df-bfcbf5f5bf8e": {
+            "gate": "22450bcf-a6a2-4dbc-a8b4-cfffe962be7b",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "bf768b4b-3c62-4f52-ac68-910ef1896730": {
+            "gate": "18277f87-68d5-423d-93c5-0f63f37aabfd",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "e63a42e9-c280-4bc3-bf38-968baa5264c1": {
+            "gate": "3805ca0e-233b-495c-91a6-271a60ddbefe",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "e7483de8-0fee-46dc-a2d6-76e13d0a4a35": {
+            "gate": "9e96838e-1bc3-4476-9af8-758580d7bebf",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "ea132ec2-ccad-48a6-8121-3aab161d5867": {
+            "gate": "fb7423db-fcf6-4898-a7fb-42ca3b2830fd",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "f0ed5f62-ebda-4736-9d7e-6894f8fb8421": {
+            "gate": "dee5dca1-1943-40ee-912d-82520cc7b584",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "cmos",
+        "ic",
+        "inverter",
+        "schmitt-trigger",
+        "tssop-14"
+    ],
+    "type": "part",
+    "uuid": "99773b16-3edb-4ec3-9079-e5df199afe4a",
+    "value": [
+        false,
+        "CM0106B"
+    ]
+}


### PR DESCRIPTION
Added the CD40106B by Texas Instruments. Datasheet is  [here](http://www.ti.com/lit/ds/symlink/cd40106b.pdf).

The part is simple and straigthforward and builds on the existing Hex Inverter Entity and existing packages, so the only point of failure should be the pin mapping.