### PR TITLE
Added Quad NAND Gates Entity and CD4011B

### DIFF
--- a/entities/logic/quad-nand.json
+++ b/entities/logic/quad-nand.json
@@ -1,0 +1,43 @@
+{
+    "gates": {
+        "2f233f4d-d4d0-4332-8f27-b2da8cda4d19": {
+            "name": "D",
+            "suffix": "D",
+            "swap_group": 1,
+            "unit": "dc4c78b6-b89a-4671-a407-c07c5e1985c0"
+        },
+        "524ddff3-77d4-428a-83a3-0909a2147dd8": {
+            "name": "B",
+            "suffix": "B",
+            "swap_group": 1,
+            "unit": "dc4c78b6-b89a-4671-a407-c07c5e1985c0"
+        },
+        "88faf4b9-af12-4313-a74e-8c80970b8884": {
+            "name": "A",
+            "suffix": "A",
+            "swap_group": 1,
+            "unit": "dc4c78b6-b89a-4671-a407-c07c5e1985c0"
+        },
+        "a7b3d48f-670b-4917-a7c2-a34614cc063f": {
+            "name": "C",
+            "suffix": "C",
+            "swap_group": 1,
+            "unit": "dc4c78b6-b89a-4671-a407-c07c5e1985c0"
+        },
+        "e5fc5e55-3e78-485b-80d2-c1856628a05b": {
+            "name": "Power",
+            "suffix": "P",
+            "swap_group": 0,
+            "unit": "c5b399c9-5626-4cc6-b33d-5c0f3da5df5c"
+        }
+    },
+    "manufacturer": "",
+    "name": "Quad NAND gate",
+    "prefix": "U",
+    "tags": [
+        "digital",
+        "logic"
+    ],
+    "type": "entity",
+    "uuid": "0ff15305-7895-452b-a045-8f08924ddd75"
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BE.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BE.json
@@ -1,0 +1,97 @@
+{
+    "MPN": [
+        false,
+        "CD4011BE"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        false,
+        "CMOS Quad NAND Gates"
+    ],
+    "entity": "0ff15305-7895-452b-a045-8f08924ddd75",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "07e2d21f-ce33-4c58-9d56-6b2dce0e6919",
+    "pad_map": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "gate": "e5fc5e55-3e78-485b-80d2-c1856628a05b",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "e5fc5e55-3e78-485b-80d2-c1856628a05b",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "cmos",
+        "digital",
+        "dip-14",
+        "ic",
+        "logic",
+        "nand",
+        "quad"
+    ],
+    "type": "part",
+    "uuid": "6d3fbbbf-e702-4009-ade5-bf0474090477",
+    "value": [
+        false,
+        "CD4011BE"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BM.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BM.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BM"
+    ],
+    "base": "7e04b94f-89ee-488b-a9a5-d53eea7fa753",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "f45f7666-04c9-4697-afc5-d8da49eeb54d",
+    "value": [
+        true,
+        "CD4011BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BM96.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BM96.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BM96"
+    ],
+    "base": "7e04b94f-89ee-488b-a9a5-d53eea7fa753",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "c05a9851-cecb-448b-9db8-e5def5e24e87",
+    "value": [
+        true,
+        "CD4011BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BM96E4.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BM96E4.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BM96E4"
+    ],
+    "base": "7e04b94f-89ee-488b-a9a5-d53eea7fa753",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "90b23d94-bb3e-4aa9-9130-fab7ee23e5c4",
+    "value": [
+        true,
+        "CD4011BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BME4.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BME4.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BME4"
+    ],
+    "base": "7e04b94f-89ee-488b-a9a5-d53eea7fa753",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "f05e9270-7bde-4b9b-8f1a-c9cbd8054179",
+    "value": [
+        true,
+        "CD4011BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BMT.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BMT.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BMT"
+    ],
+    "base": "7e04b94f-89ee-488b-a9a5-d53eea7fa753",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "d5d9469b-16da-4e6b-ae4a-729658f58cb3",
+    "value": [
+        true,
+        "CD4011BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BM_Base.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BM_Base.json
@@ -1,0 +1,97 @@
+{
+    "MPN": [
+        false,
+        "CD4011BM (Base)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        false,
+        "CMOS Quad NAND Gates"
+    ],
+    "entity": "0ff15305-7895-452b-a045-8f08924ddd75",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "14aeb235-3edc-4327-9a25-7de5a4bd6808",
+    "pad_map": {
+        "150ac7fa-7f46-49f2-ab10-8c0f447d0bd4": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "29845fb8-d37b-4a23-a456-3897cba0240e": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "32350e73-3524-4259-aad9-74a372ee42e5": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "327e4032-c988-4b9b-8944-cd6e4257ca8e": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "38f25dfc-b2f4-4515-83fb-f63c0c529fc9": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "6de88445-a438-452d-9a56-ca754d9c97f8": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "71284ebf-b339-4f0d-bd5f-765d1eb04896": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "7d774933-233f-42d6-aa61-645fccad511f": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "7e3e50d4-f9a5-4b8d-80bb-9c119b9c88ed": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "8a7ba3f8-c2ff-4736-a7af-63bc6b28775a": {
+            "gate": "e5fc5e55-3e78-485b-80d2-c1856628a05b",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "ce8e0ff3-c8cb-430b-b47d-4f16d58bb7f3": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "cf3a38df-5ed7-47dd-84ce-0f9d0a0ba9d1": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "d86bca97-5554-479a-8512-843a86f676e5": {
+            "gate": "e5fc5e55-3e78-485b-80d2-c1856628a05b",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "dd326f38-d93c-4563-a442-d5334a8426d3": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "cmos",
+        "digital",
+        "ic",
+        "logic",
+        "nand",
+        "quad",
+        "soic-14"
+    ],
+    "type": "part",
+    "uuid": "7e04b94f-89ee-488b-a9a5-d53eea7fa753",
+    "value": [
+        false,
+        "CD4011BM"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BPW.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BPW.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BPW"
+    ],
+    "base": "703b1aff-d818-4f5a-9f0b-11e9bb8feacf",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "80fe4d0a-7773-4aae-9842-aedae46e437b",
+    "value": [
+        true,
+        "CD4011BPW"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BPWE4.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BPWE4.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BPWE4"
+    ],
+    "base": "703b1aff-d818-4f5a-9f0b-11e9bb8feacf",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "8e5b0028-59e2-4a6d-a5f8-d30fbd61d8ff",
+    "value": [
+        true,
+        "CD4011BPW"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BPWR.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BPWR.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BPWR"
+    ],
+    "base": "703b1aff-d818-4f5a-9f0b-11e9bb8feacf",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "94780e96-c645-47a4-82dd-f14a8c9864b8",
+    "value": [
+        true,
+        "CD4011BPW"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BPWRG4.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BPWRG4.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "CD4011BPWRG4"
+    ],
+    "base": "703b1aff-d818-4f5a-9f0b-11e9bb8feacf",
+    "datasheet": [
+        true,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        true,
+        "CMOS Quad NAND Gates"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "5ca05955-3ce5-4b20-a5de-8bf8f748a674",
+    "value": [
+        true,
+        "CD4011BPW"
+    ]
+}

--- a/parts/ic/logic/ti/CD4011BE/CD4011BPW_Base.json
+++ b/parts/ic/logic/ti/CD4011BE/CD4011BPW_Base.json
@@ -1,0 +1,97 @@
+{
+    "MPN": [
+        false,
+        "CD4011BPW (Base)"
+    ],
+    "datasheet": [
+        false,
+        "http://www.ti.com/lit/ds/symlink/cd4011b.pdf"
+    ],
+    "description": [
+        false,
+        "CMOS Quad NAND Gates"
+    ],
+    "entity": "0ff15305-7895-452b-a045-8f08924ddd75",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "12001aad-23c9-46d2-bfdb-75ffd2479776",
+    "pad_map": {
+        "261fe7ff-1e20-45bc-b96f-0733c16960c4": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "427439e3-355e-4c65-a502-338cba5d0f4b": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "46ab3d42-b140-4167-939f-00bebcccfc22": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "48201ebb-e791-4c91-9bdb-fc069831ade8": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "5ea90398-774b-43ec-bd14-db28ef507b64": {
+            "gate": "e5fc5e55-3e78-485b-80d2-c1856628a05b",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "64731022-0d14-4c0a-996c-3eed9f417c00": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "6e7efadb-0a82-4a26-8965-513d6ff56219": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "af643901-6c38-4b1b-b30c-371212d093f7": {
+            "gate": "e5fc5e55-3e78-485b-80d2-c1856628a05b",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "b37a46a0-e07e-45ef-87df-bfcbf5f5bf8e": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "bf768b4b-3c62-4f52-ac68-910ef1896730": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "a8c0d3aa-71cd-480d-864d-94ed747d6695"
+        },
+        "e63a42e9-c280-4bc3-bf38-968baa5264c1": {
+            "gate": "88faf4b9-af12-4313-a74e-8c80970b8884",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "e7483de8-0fee-46dc-a2d6-76e13d0a4a35": {
+            "gate": "2f233f4d-d4d0-4332-8f27-b2da8cda4d19",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        },
+        "ea132ec2-ccad-48a6-8121-3aab161d5867": {
+            "gate": "a7b3d48f-670b-4917-a7c2-a34614cc063f",
+            "pin": "5479c8c9-6bd5-42ba-ad29-9d0042523354"
+        },
+        "f0ed5f62-ebda-4736-9d7e-6894f8fb8421": {
+            "gate": "524ddff3-77d4-428a-83a3-0909a2147dd8",
+            "pin": "79f885fa-a434-44c1-94d8-c0728e4fc2eb"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "cmos",
+        "digital",
+        "ic",
+        "logic",
+        "nand",
+        "quad",
+        "tssop-14"
+    ],
+    "type": "part",
+    "uuid": "703b1aff-d818-4f5a-9f0b-11e9bb8feacf",
+    "value": [
+        false,
+        "CD4011BPW"
+    ]
+}


### PR DESCRIPTION
Added the CD4011B by Texas Instruments. Datasheet is  [here](http://www.ti.com/lit/ds/symlink/cd4011b.pdf).

There was no Quad NAND Gates Entity (Units and Symbols existed tho), so I made one based on the existing Quad AND Gate Entity. The rest is pretty standard