### PR TITLE
Added 2N7000 Small Signal N-Channel Mosfet

### DIFF
--- a/parts/transistor/nmos/2N7000/2N7000 (Base).json
+++ b/parts/transistor/nmos/2N7000/2N7000 (Base).json
@@ -1,0 +1,49 @@
+{
+    "MPN": [
+        false,
+        "2N7000G (Base)"
+    ],
+    "datasheet": [
+        false,
+        "https://www.onsemi.com/pub/Collateral/2N7000-D.PDF"
+    ],
+    "description": [
+        false,
+        "Small Signal N-Channel MOSFET 200 mAs, 60V"
+    ],
+    "entity": "c135130c-0663-4575-9083-3b328ac00c90",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "f94aec49-d6bf-4170-8d54-ba567cd9c9ea",
+    "pad_map": {
+        "0c65f99f-5e80-482c-abf3-5a46acfd1174": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "eb63ac9a-5d7e-42e2-92ea-a140a97f47d0"
+        },
+        "2857d642-7cf6-4eb9-8741-6249df6c8cab": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "4887ef47-94f0-4fd1-b552-c424bd37a3e7"
+        },
+        "5d851f2d-3f8d-4732-b7e2-5a1c7eae2766": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "074c3718-08fd-4f94-88fc-2bb43174b245"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "mosfet",
+        "n-channel",
+        "to-92"
+    ],
+    "type": "part",
+    "uuid": "3c191fb0-bd8f-4e9c-b4a8-7df4227b0cba",
+    "value": [
+        false,
+        "2N7000"
+    ]
+}

--- a/parts/transistor/nmos/2N7000/2N7000-D26Z.json
+++ b/parts/transistor/nmos/2N7000/2N7000-D26Z.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N7000-D26Z"
+    ],
+    "base": "3c191fb0-bd8f-4e9c-b4a8-7df4227b0cba",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N7000-D.PDF"
+    ],
+    "description": [
+        true,
+        "Small Signal N-Channel MOSFET 200 mAs, 60V"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "2b18e6f7-b0d8-425b-b0ff-1e40608f7fdf",
+    "value": [
+        true,
+        "2N7000"
+    ]
+}

--- a/parts/transistor/nmos/2N7000/2N7000-D74Z.json
+++ b/parts/transistor/nmos/2N7000/2N7000-D74Z.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N7000-D74Z"
+    ],
+    "base": "3c191fb0-bd8f-4e9c-b4a8-7df4227b0cba",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N7000-D.PDF"
+    ],
+    "description": [
+        true,
+        "Small Signal N-Channel MOSFET 200 mAs, 60V"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "dbbdce94-3b38-433e-9ae0-5a6eb5c71017",
+    "value": [
+        true,
+        "2N7000"
+    ]
+}

--- a/parts/transistor/nmos/2N7000/2N7000-D75Z.json
+++ b/parts/transistor/nmos/2N7000/2N7000-D75Z.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N7000-D75Z"
+    ],
+    "base": "3c191fb0-bd8f-4e9c-b4a8-7df4227b0cba",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N7000-D.PDF"
+    ],
+    "description": [
+        true,
+        "Small Signal N-Channel MOSFET 200 mAs, 60V"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "2ed3452f-1b2a-4641-9160-94b9caa684b4",
+    "value": [
+        true,
+        "2N7000"
+    ]
+}

--- a/parts/transistor/nmos/2N7000/2N7000.json
+++ b/parts/transistor/nmos/2N7000/2N7000.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N7000"
+    ],
+    "base": "3c191fb0-bd8f-4e9c-b4a8-7df4227b0cba",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N7000-D.PDF"
+    ],
+    "description": [
+        true,
+        "Small Signal N-Channel MOSFET 200 mAs, 60V"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "3bb100e7-5bec-483d-a13a-580affacf4ca",
+    "value": [
+        true,
+        "2N7000"
+    ]
+}

--- a/parts/transistor/nmos/2N7000/2N7000BU.json
+++ b/parts/transistor/nmos/2N7000/2N7000BU.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N7000BU"
+    ],
+    "base": "3c191fb0-bd8f-4e9c-b4a8-7df4227b0cba",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N7000-D.PDF"
+    ],
+    "description": [
+        true,
+        "Small Signal N-Channel MOSFET 200 mAs, 60V"
+    ],
+    "inherit_model": true,
+    "inherit_tags": false,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "a151817f-a02a-4ddf-85b2-1e05ecd4d09f",
+    "value": [
+        true,
+        "2N7000"
+    ]
+}

--- a/parts/transistor/nmos/2N7000/2N7000TA.json
+++ b/parts/transistor/nmos/2N7000/2N7000TA.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "2N7000TA"
+    ],
+    "base": "3c191fb0-bd8f-4e9c-b4a8-7df4227b0cba",
+    "datasheet": [
+        true,
+        "https://www.onsemi.com/pub/Collateral/2N7000-D.PDF"
+    ],
+    "description": [
+        true,
+        "Small Signal N-Channel MOSFET 200 mAs, 60V"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ON Semiconductor"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "c8ba1983-1577-4d7a-af1e-956bf71dba35",
+    "value": [
+        true,
+        "2N7000"
+    ]
+}


### PR DESCRIPTION
Added the [2N7000](https://www.onsemi.com/pub/Collateral/2N7000-D.PDF) by On Semi.
The MPNs are a bit confusing, because the Datasheet is for the 2N7000G, but I only found the part under different MPNs as buyable. But I think it is ok.