### PR TITLE
Harmonize BC8x6AS manufacturer names to pool

### DIFF
--- a/parts/transistor/BC846AS.json
+++ b/parts/transistor/BC846AS.json
@@ -12,12 +12,13 @@
         "Dual NPN small Signal Transistor"
     ],
     "entity": "b6bd69e8-3d96-47d3-89e8-5802b2451373",
+    "inherit_model": false,
     "inherit_tags": false,
     "manufacturer": [
         false,
-        "Diodes Incorporated"
+        "Diodes Inc."
     ],
-    "model": "00000000-0000-0000-0000-000000000000",
+    "model": "b7a19b51-324c-4ce9-91f8-ca7b2ab55465",
     "package": "1e7c3ae3-1526-4b8c-8cb8-726207c3667d",
     "pad_map": {
         "15f6028d-b6d0-46e4-b9b9-716367c20e52": {

--- a/parts/transistor/BC856AS.json
+++ b/parts/transistor/BC856AS.json
@@ -12,18 +12,15 @@
         "Dual PNP Small Signal Transistor"
     ],
     "entity": "f2443156-b218-4979-b244-20ef0bf2476a",
+    "inherit_model": false,
     "inherit_tags": false,
     "manufacturer": [
         false,
-        "Diodes Incorporated"
+        "Diodes Inc."
     ],
-    "model": "00000000-0000-0000-0000-000000000000",
+    "model": "b7a19b51-324c-4ce9-91f8-ca7b2ab55465",
     "package": "1e7c3ae3-1526-4b8c-8cb8-726207c3667d",
     "pad_map": {
-        "15f6028d-b6d0-46e4-b9b9-716367c20e52": {
-            "gate": "79977dc5-4fdb-4ff6-a4f8-a9199da1de47",
-            "pin": "7c4ac8a6-e267-48cd-89d5-28ed30de088a"
-        },
         "5afe2207-9077-4f3a-99be-9513e98634c1": {
             "gate": "40ce877c-ec96-4b42-acad-4860f7587fd1",
             "pin": "6bd7bb7b-95c6-4ed4-9a71-55f5e3b72a92"
@@ -32,17 +29,9 @@
             "gate": "40ce877c-ec96-4b42-acad-4860f7587fd1",
             "pin": "f915c514-c206-40fc-8a4a-46a259d4f80e"
         },
-        "a1db159f-a415-41e4-a920-6855ab964aac": {
-            "gate": "79977dc5-4fdb-4ff6-a4f8-a9199da1de47",
-            "pin": "6bd7bb7b-95c6-4ed4-9a71-55f5e3b72a92"
-        },
         "c28851fa-1824-44f1-849e-1c7571be475a": {
             "gate": "40ce877c-ec96-4b42-acad-4860f7587fd1",
             "pin": "7c4ac8a6-e267-48cd-89d5-28ed30de088a"
-        },
-        "ebfdb9dd-81b5-4d3d-9e9b-05c93f156cb3": {
-            "gate": "79977dc5-4fdb-4ff6-a4f8-a9199da1de47",
-            "pin": "f915c514-c206-40fc-8a4a-46a259d4f80e"
         }
     },
     "parametric": {},


### PR DESCRIPTION
This changes the manufacturer names from `Diodes Incorporated` to `Diodes Inc` in order to match the existing pool.