### PR TITLE
Added MCP300x ADC series

### DIFF
--- a/entities/ic/adc/microchip/MCP3001.json
+++ b/entities/ic/adc/microchip/MCP3001.json
@@ -1,0 +1,22 @@
+{
+    "gates": {
+        "dc99a18c-342e-4a53-a117-e8b560dca7e9": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "23de0c4f-a053-40c1-9204-eab8517b13c5"
+        }
+    },
+    "manufacturer": "Microchip",
+    "name": "MCP3001",
+    "prefix": "U",
+    "tags": [
+        "10-bit",
+        "adc",
+        "ic",
+        "single",
+        "spi"
+    ],
+    "type": "entity",
+    "uuid": "9b6061df-e6fb-4718-9088-94293c6863cd"
+}

--- a/entities/ic/adc/microchip/MCP3002.json
+++ b/entities/ic/adc/microchip/MCP3002.json
@@ -1,0 +1,22 @@
+{
+    "gates": {
+        "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "411f6247-d754-409b-a1e6-ed09006e87a3"
+        }
+    },
+    "manufacturer": "Microchip",
+    "name": "MCP3002",
+    "prefix": "U",
+    "tags": [
+        "10-bit",
+        "adc",
+        "dual",
+        "ic",
+        "spi"
+    ],
+    "type": "entity",
+    "uuid": "138166e1-f262-45d7-8dce-43ef8ad8ee64"
+}

--- a/entities/ic/adc/microchip/MCP3004.json
+++ b/entities/ic/adc/microchip/MCP3004.json
@@ -1,0 +1,22 @@
+{
+    "gates": {
+        "8b37ffd7-19c3-4541-a02b-ffc0463e9755": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "70aa1b25-35fe-4b4c-a1d2-ca14ba3192df"
+        }
+    },
+    "manufacturer": "Microchip",
+    "name": "MCP3004",
+    "prefix": "U",
+    "tags": [
+        "10-bit",
+        "adc",
+        "ic",
+        "quad",
+        "spi"
+    ],
+    "type": "entity",
+    "uuid": "daabab81-35a6-4455-84b9-29ff1fcf4a0f"
+}

--- a/entities/ic/adc/microchip/MCP3008.json
+++ b/entities/ic/adc/microchip/MCP3008.json
@@ -1,0 +1,22 @@
+{
+    "gates": {
+        "37a9ad40-2150-4167-b7b9-0de630974751": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "7f8202ae-efad-4b06-8d44-ff5f79df3a0e"
+        }
+    },
+    "manufacturer": "Microchip",
+    "name": "MCP3008",
+    "prefix": "U",
+    "tags": [
+        "10-bit",
+        "8-channel",
+        "adc",
+        "ic",
+        "spi"
+    ],
+    "type": "entity",
+    "uuid": "981606c2-4943-49bd-86b4-db4bc46f6810"
+}

--- a/packages/ic/smd/soic/so-16/package.json
+++ b/packages/ic/smd/soic/so-16/package.json
@@ -1,0 +1,578 @@
+{
+    "_imp": {
+        "grid_spacing": 1270000,
+        "layer_display": {
+            "layer_opacity": 50.0,
+            "layers": {
+                "-1": {
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-100": {
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "-110": {
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-120": {
+                    "display_mode": "fill_only",
+                    "visible": false
+                },
+                "-130": {
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "-140": {
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-150": {
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "-160": {
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "0": {
+                    "display_mode": "fill",
+                    "visible": true
+                },
+                "10": {
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "20": {
+                    "display_mode": "fill_only",
+                    "visible": true
+                },
+                "30": {
+                    "display_mode": "fill",
+                    "visible": false
+                },
+                "40": {
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "50": {
+                    "display_mode": "outline",
+                    "visible": true
+                },
+                "60": {
+                    "display_mode": "outline",
+                    "visible": true
+                }
+            }
+        }
+    },
+    "arcs": {},
+    "default_model": "9a0026d7-be20-4450-a466-94c4e77d536d",
+    "junctions": {
+        "178eb954-c0de-415e-bd97-0604079c1665": {
+            "position": [
+                -1949999,
+                -5135000
+            ]
+        },
+        "9dbc0a38-e8fc-41bf-9fdb-497e831edd44": {
+            "position": [
+                1949999,
+                -5135000
+            ]
+        },
+        "b3e69fba-8047-4659-8ddb-8c4702c416ea": {
+            "position": [
+                -2100000,
+                5035000
+            ]
+        },
+        "c0ed33d9-b56d-4d14-8953-800f01a48be2": {
+            "position": [
+                -2100000,
+                5135000
+            ]
+        },
+        "e65c392a-df30-4f7e-b6d2-85c1e787ac37": {
+            "position": [
+                -3400000,
+                5035000
+            ]
+        },
+        "e8d345e5-30be-4b11-b82d-84f47ab0792b": {
+            "position": [
+                1950000,
+                5135000
+            ]
+        }
+    },
+    "keepouts": {},
+    "lines": {
+        "481feb34-83e6-4456-9912-a0c1c28289fc": {
+            "from": "c0ed33d9-b56d-4d14-8953-800f01a48be2",
+            "layer": 20,
+            "to": "e8d345e5-30be-4b11-b82d-84f47ab0792b",
+            "width": 150000
+        },
+        "4ce7e2cd-77b1-4e4f-b5c9-91238e64523d": {
+            "from": "c0ed33d9-b56d-4d14-8953-800f01a48be2",
+            "layer": 20,
+            "to": "b3e69fba-8047-4659-8ddb-8c4702c416ea",
+            "width": 150000
+        },
+        "4df38702-f5fd-4b99-abe4-f26f9cace840": {
+            "from": "178eb954-c0de-415e-bd97-0604079c1665",
+            "layer": 20,
+            "to": "9dbc0a38-e8fc-41bf-9fdb-497e831edd44",
+            "width": 150000
+        },
+        "67d2c067-019e-4c3e-8fa7-77c8bdfd59ec": {
+            "from": "b3e69fba-8047-4659-8ddb-8c4702c416ea",
+            "layer": 20,
+            "to": "e65c392a-df30-4f7e-b6d2-85c1e787ac37",
+            "width": 150000
+        }
+    },
+    "manufacturer": "",
+    "models": {
+        "9a0026d7-be20-4450-a466-94c4e77d536d": {
+            "filename": "3d_models/ic/so/SOIC-16_3.9x9.9mm_P1.27mm.step",
+            "pitch": 0,
+            "roll": 0,
+            "x": 0,
+            "y": 0,
+            "yaw": 0,
+            "z": 0
+        }
+    },
+    "name": "SOIC-16",
+    "pads": {
+        "150ac7fa-7f46-49f2-ab10-8c0f447d0bd4": {
+            "name": "5",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    -635000
+                ]
+            }
+        },
+        "29845fb8-d37b-4a23-a456-3897cba0240e": {
+            "name": "3",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    1905000
+                ]
+            }
+        },
+        "32350e73-3524-4259-aad9-74a372ee42e5": {
+            "name": "10",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    -3175000
+                ]
+            }
+        },
+        "327e4032-c988-4b9b-8944-cd6e4257ca8e": {
+            "name": "1",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    4445000
+                ]
+            }
+        },
+        "38f25dfc-b2f4-4515-83fb-f63c0c529fc9": {
+            "name": "9",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    -4445000
+                ]
+            }
+        },
+        "6de88445-a438-452d-9a56-ca754d9c97f8": {
+            "name": "11",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    -1905000
+                ]
+            }
+        },
+        "6ed9ccb5-ed6a-42a3-9783-7667d4dd997a": {
+            "name": "16",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    4445000
+                ]
+            }
+        },
+        "71284ebf-b339-4f0d-bd5f-765d1eb04896": {
+            "name": "6",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    -1905000
+                ]
+            }
+        },
+        "7b4e112f-ab67-4389-b475-7c491f95b444": {
+            "name": "15",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    3175000
+                ]
+            }
+        },
+        "7d774933-233f-42d6-aa61-645fccad511f": {
+            "name": "12",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    -635000
+                ]
+            }
+        },
+        "7e3e50d4-f9a5-4b8d-80bb-9c119b9c88ed": {
+            "name": "4",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    635000
+                ]
+            }
+        },
+        "8a7ba3f8-c2ff-4736-a7af-63bc6b28775a": {
+            "name": "14",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    1905000
+                ]
+            }
+        },
+        "ce8e0ff3-c8cb-430b-b47d-4f16d58bb7f3": {
+            "name": "13",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    635000
+                ]
+            }
+        },
+        "cf3a38df-5ed7-47dd-84ce-0f9d0a0ba9d1": {
+            "name": "2",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    3175000
+                ]
+            }
+        },
+        "d86bca97-5554-479a-8512-843a86f676e5": {
+            "name": "7",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    -3175000
+                ]
+            }
+        },
+        "dd326f38-d93c-4563-a442-d5334a8426d3": {
+            "name": "8",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1500000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    -4445000
+                ]
+            }
+        }
+    },
+    "parameter_program": "6.9mm 8.7mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0 0 ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "c00af7b5-6bf4-4bc1-a4f5-1c8398832a80": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        5300000,
+                        1975000
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1950000,
+                        4985000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        6700000,
+                        1975000
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1950000,
+                        4985000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        6700000,
+                        -1975000
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1950000,
+                        -4985000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        5300000,
+                        -1975000
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1950000,
+                        -4985000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "ff2197e2-c7b1-4569-a5de-8e5a6dd74c2d": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        6000000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1950000,
+                        -4985000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        6000000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1950000,
+                        -4985000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        6000000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1950000,
+                        4985000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        6050000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -950000,
+                        4985000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        6000000,
+                        -600000
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1950000,
+                        3985000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "tags": [
+        "generic",
+        "ic",
+        "smd",
+        "soic"
+    ],
+    "texts": {
+        "64389f00-54d2-4146-bef6-f5d6cdbbb5db": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    0,
+                    4985000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 0
+        },
+        "b6f7759a-1900-4731-9066-5a7a323dc360": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3400000,
+                    6035000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        }
+    },
+    "type": "package",
+    "uuid": "28245e4c-ffe9-4461-b663-b43a495e068c"
+}

--- a/parts/ic/adc/microchip/MCP3001-I_P.json
+++ b/parts/ic/adc/microchip/MCP3001-I_P.json
@@ -1,0 +1,72 @@
+{
+    "MPN": [
+        false,
+        "MCP3001-I/P"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21293C.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, Single Channel ADC"
+    ],
+    "entity": "9b6061df-e6fb-4718-9088-94293c6863cd",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "d39137d0-f433-40ab-872c-263c701420b0",
+    "pad_map": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "6f9bd078-4fe9-4516-915a-9dd287642e67"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "17a5f2b7-f0b6-495d-8d1f-ad2d5ccb1e61"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "e3f47dec-5623-49de-bc07-dff14be6576c"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "71c73b6a-0f31-49c1-b83b-fb35b8d5a49f"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "a2e867f7-46bc-4b01-9e61-07bb0f8daff3"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "eedf8571-1aea-430a-a84e-f006a60e414d"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "858f46a7-7406-4e51-929b-e7a3955ad374"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "4ca0fa3e-5568-4af6-a463-17a33b970964"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "dip-8",
+        "ic",
+        "single",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "d4b539e6-54f7-4f1d-ac26-a2e944d37149",
+    "value": [
+        false,
+        "MCP3001"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3001-I_SN.json
+++ b/parts/ic/adc/microchip/MCP3001-I_SN.json
@@ -1,0 +1,72 @@
+{
+    "MPN": [
+        false,
+        "MCP3001-I/SN"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21293C.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, Single Channel ADC"
+    ],
+    "entity": "9b6061df-e6fb-4718-9088-94293c6863cd",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "b99785a3-c0da-4658-969d-6287cec3be05",
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "17a5f2b7-f0b6-495d-8d1f-ad2d5ccb1e61"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "eedf8571-1aea-430a-a84e-f006a60e414d"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "71c73b6a-0f31-49c1-b83b-fb35b8d5a49f"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "858f46a7-7406-4e51-929b-e7a3955ad374"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "4ca0fa3e-5568-4af6-a463-17a33b970964"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "e3f47dec-5623-49de-bc07-dff14be6576c"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "6f9bd078-4fe9-4516-915a-9dd287642e67"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "a2e867f7-46bc-4b01-9e61-07bb0f8daff3"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "ic",
+        "single",
+        "soic-8",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "b134bbf6-1834-46f2-b21b-b980a21f60fa",
+    "value": [
+        false,
+        "MCP3001"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3001-I_ST.json
+++ b/parts/ic/adc/microchip/MCP3001-I_ST.json
@@ -1,0 +1,72 @@
+{
+    "MPN": [
+        false,
+        "MCP3001-I/ST"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21293C.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, Single Channel ADC"
+    ],
+    "entity": "9b6061df-e6fb-4718-9088-94293c6863cd",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "bc78d24c-ca26-458f-826b-a92ca324c6ad",
+    "pad_map": {
+        "04ac7a75-b417-45b1-b5c9-6e883550999c": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "a2e867f7-46bc-4b01-9e61-07bb0f8daff3"
+        },
+        "122635cd-5ea3-42d5-8c67-1371fd145f90": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "17a5f2b7-f0b6-495d-8d1f-ad2d5ccb1e61"
+        },
+        "26b473ad-8fbe-4640-bf0b-169061ededd2": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "858f46a7-7406-4e51-929b-e7a3955ad374"
+        },
+        "2b67d97f-f271-448a-97fe-33d9f13b3dc6": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "eedf8571-1aea-430a-a84e-f006a60e414d"
+        },
+        "3b17f6b4-4794-4a2d-a384-7fbbc416f4fb": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "71c73b6a-0f31-49c1-b83b-fb35b8d5a49f"
+        },
+        "4630934f-b688-468f-8107-7678ac07c6da": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "4ca0fa3e-5568-4af6-a463-17a33b970964"
+        },
+        "5a7902da-b874-47b9-a949-4a96710298a9": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "6f9bd078-4fe9-4516-915a-9dd287642e67"
+        },
+        "889890d1-7957-4255-9ce1-576e7d23b7ae": {
+            "gate": "dc99a18c-342e-4a53-a117-e8b560dca7e9",
+            "pin": "e3f47dec-5623-49de-bc07-dff14be6576c"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "ic",
+        "single",
+        "spi",
+        "tssop-8"
+    ],
+    "type": "part",
+    "uuid": "9569f068-49e7-4dc8-b237-c08b95486f81",
+    "value": [
+        false,
+        "MCP3001"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3002-I_P.json
+++ b/parts/ic/adc/microchip/MCP3002-I_P.json
@@ -1,0 +1,72 @@
+{
+    "MPN": [
+        false,
+        "MCP3002-I/P"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21294E.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, Dual Channel ADC"
+    ],
+    "entity": "138166e1-f262-45d7-8dce-43ef8ad8ee64",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "d39137d0-f433-40ab-872c-263c701420b0",
+    "pad_map": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "f16f9abf-58b1-485b-a653-6dd990a36994"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "108cc5a3-8126-4929-becc-0f3eff07984c"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "afba04ee-2185-4ba1-abc5-bd0bc6aa4590"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "9098946b-6826-4f8f-b866-ec4b8a8a4e74"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "22e577dc-c37a-479c-bac5-67b33552c432"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "72460bec-bfc3-45be-bcef-1ddbf5d8382f"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "3635c69a-d0ed-4271-97c1-ee6c2a1da303"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "32cd7fd5-6980-4610-908a-2cfaf151c679"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "dip-8",
+        "dual",
+        "ic",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "fd2cc384-b5ba-49f7-a8ad-1cdd5c8da29f",
+    "value": [
+        false,
+        "MCP3002"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3002-I_SN.json
+++ b/parts/ic/adc/microchip/MCP3002-I_SN.json
@@ -1,0 +1,72 @@
+{
+    "MPN": [
+        false,
+        "MCP3002-I/SN"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21294E.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, Dual Channel ADC"
+    ],
+    "entity": "138166e1-f262-45d7-8dce-43ef8ad8ee64",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "b99785a3-c0da-4658-969d-6287cec3be05",
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "108cc5a3-8126-4929-becc-0f3eff07984c"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "72460bec-bfc3-45be-bcef-1ddbf5d8382f"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "9098946b-6826-4f8f-b866-ec4b8a8a4e74"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "3635c69a-d0ed-4271-97c1-ee6c2a1da303"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "32cd7fd5-6980-4610-908a-2cfaf151c679"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "afba04ee-2185-4ba1-abc5-bd0bc6aa4590"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "f16f9abf-58b1-485b-a653-6dd990a36994"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "22e577dc-c37a-479c-bac5-67b33552c432"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "dual",
+        "ic",
+        "soic-8",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "2ff8017e-42db-47c6-8df0-123d245619fc",
+    "value": [
+        false,
+        "MCP3002"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3002-I_ST.json
+++ b/parts/ic/adc/microchip/MCP3002-I_ST.json
@@ -1,0 +1,72 @@
+{
+    "MPN": [
+        false,
+        "MCP3002-I/ST"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21294E.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, Dual Channel ADC"
+    ],
+    "entity": "138166e1-f262-45d7-8dce-43ef8ad8ee64",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "bc78d24c-ca26-458f-826b-a92ca324c6ad",
+    "pad_map": {
+        "04ac7a75-b417-45b1-b5c9-6e883550999c": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "22e577dc-c37a-479c-bac5-67b33552c432"
+        },
+        "122635cd-5ea3-42d5-8c67-1371fd145f90": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "108cc5a3-8126-4929-becc-0f3eff07984c"
+        },
+        "26b473ad-8fbe-4640-bf0b-169061ededd2": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "3635c69a-d0ed-4271-97c1-ee6c2a1da303"
+        },
+        "2b67d97f-f271-448a-97fe-33d9f13b3dc6": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "72460bec-bfc3-45be-bcef-1ddbf5d8382f"
+        },
+        "3b17f6b4-4794-4a2d-a384-7fbbc416f4fb": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "9098946b-6826-4f8f-b866-ec4b8a8a4e74"
+        },
+        "4630934f-b688-468f-8107-7678ac07c6da": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "32cd7fd5-6980-4610-908a-2cfaf151c679"
+        },
+        "5a7902da-b874-47b9-a949-4a96710298a9": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "f16f9abf-58b1-485b-a653-6dd990a36994"
+        },
+        "889890d1-7957-4255-9ce1-576e7d23b7ae": {
+            "gate": "605ba043-c7bc-4a2b-8cfb-e1ceeb5845bb",
+            "pin": "afba04ee-2185-4ba1-abc5-bd0bc6aa4590"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "dual",
+        "ic",
+        "spi",
+        "tssop-8"
+    ],
+    "type": "part",
+    "uuid": "fbb1e4d3-6a78-450b-9eb3-5df055c9983a",
+    "value": [
+        false,
+        "MCP3002"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3004-I_P.json
+++ b/parts/ic/adc/microchip/MCP3004-I_P.json
@@ -1,0 +1,88 @@
+{
+    "MPN": [
+        false,
+        "MCP3004-I/P"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21295d.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, 4-Channel ADC"
+    ],
+    "entity": "daabab81-35a6-4455-84b9-29ff1fcf4a0f",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "07e2d21f-ce33-4c58-9d56-6b2dce0e6919",
+    "pad_map": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "fbd4ff3a-ee52-4a3f-a5b8-22f1db44df60"
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "f0dce350-e975-4700-bc8d-e75c80227ef0"
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "766777bc-83c4-445c-8ae9-74b73ed357b0"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "b72aca52-6edd-485e-b4b1-bfb35f22b5de"
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "c5f70843-f219-4460-b980-4c2e7828cbe3"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "a272d34c-04af-4e15-aa4b-abc844e3c9b6"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "96841b5d-2763-4543-b796-d1ef7bb8e52a"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "fb22bccd-38ab-4e67-a728-883f6d4edf74"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "662d9dd0-bb47-4e15-a1c3-bde4d0d24810"
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "1d74f2f6-ff3a-4940-bdb8-0ca5767dee6a"
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "00537ab8-a132-47c3-af9e-0bbe1d7ad8d9"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "2a3e1f15-90f2-4be5-bb89-f13b865e6b5b"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "dip-14",
+        "ic",
+        "quad",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "61055ff4-a2af-4d9a-86b8-87419ab6f88c",
+    "value": [
+        false,
+        "MCP3004"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3004-I_SL.json
+++ b/parts/ic/adc/microchip/MCP3004-I_SL.json
@@ -1,0 +1,88 @@
+{
+    "MPN": [
+        false,
+        "MCP3004-I/SL"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21295d.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, 4-Channel ADC"
+    ],
+    "entity": "daabab81-35a6-4455-84b9-29ff1fcf4a0f",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "14aeb235-3edc-4327-9a25-7de5a4bd6808",
+    "pad_map": {
+        "29845fb8-d37b-4a23-a456-3897cba0240e": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "2a3e1f15-90f2-4be5-bb89-f13b865e6b5b"
+        },
+        "32350e73-3524-4259-aad9-74a372ee42e5": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "c5f70843-f219-4460-b980-4c2e7828cbe3"
+        },
+        "327e4032-c988-4b9b-8944-cd6e4257ca8e": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "662d9dd0-bb47-4e15-a1c3-bde4d0d24810"
+        },
+        "38f25dfc-b2f4-4515-83fb-f63c0c529fc9": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "f0dce350-e975-4700-bc8d-e75c80227ef0"
+        },
+        "6de88445-a438-452d-9a56-ca754d9c97f8": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "1d74f2f6-ff3a-4940-bdb8-0ca5767dee6a"
+        },
+        "7d774933-233f-42d6-aa61-645fccad511f": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "fbd4ff3a-ee52-4a3f-a5b8-22f1db44df60"
+        },
+        "7e3e50d4-f9a5-4b8d-80bb-9c119b9c88ed": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "fb22bccd-38ab-4e67-a728-883f6d4edf74"
+        },
+        "8a7ba3f8-c2ff-4736-a7af-63bc6b28775a": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "766777bc-83c4-445c-8ae9-74b73ed357b0"
+        },
+        "ce8e0ff3-c8cb-430b-b47d-4f16d58bb7f3": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "00537ab8-a132-47c3-af9e-0bbe1d7ad8d9"
+        },
+        "cf3a38df-5ed7-47dd-84ce-0f9d0a0ba9d1": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "b72aca52-6edd-485e-b4b1-bfb35f22b5de"
+        },
+        "d86bca97-5554-479a-8512-843a86f676e5": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "a272d34c-04af-4e15-aa4b-abc844e3c9b6"
+        },
+        "dd326f38-d93c-4563-a442-d5334a8426d3": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "96841b5d-2763-4543-b796-d1ef7bb8e52a"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "ic",
+        "quad",
+        "soic-14",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "d92963d1-7fc4-4754-bcb9-2b3497960fa2",
+    "value": [
+        false,
+        "MCP3004"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3004-I_ST.json
+++ b/parts/ic/adc/microchip/MCP3004-I_ST.json
@@ -1,0 +1,88 @@
+{
+    "MPN": [
+        false,
+        "MCP3004-I/ST"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21295d.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, 4-Channel ADC"
+    ],
+    "entity": "daabab81-35a6-4455-84b9-29ff1fcf4a0f",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "12001aad-23c9-46d2-bfdb-75ffd2479776",
+    "pad_map": {
+        "427439e3-355e-4c65-a502-338cba5d0f4b": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "fbd4ff3a-ee52-4a3f-a5b8-22f1db44df60"
+        },
+        "46ab3d42-b140-4167-939f-00bebcccfc22": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "96841b5d-2763-4543-b796-d1ef7bb8e52a"
+        },
+        "48201ebb-e791-4c91-9bdb-fc069831ade8": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "c5f70843-f219-4460-b980-4c2e7828cbe3"
+        },
+        "5ea90398-774b-43ec-bd14-db28ef507b64": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "766777bc-83c4-445c-8ae9-74b73ed357b0"
+        },
+        "64731022-0d14-4c0a-996c-3eed9f417c00": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "662d9dd0-bb47-4e15-a1c3-bde4d0d24810"
+        },
+        "6e7efadb-0a82-4a26-8965-513d6ff56219": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "fb22bccd-38ab-4e67-a728-883f6d4edf74"
+        },
+        "af643901-6c38-4b1b-b30c-371212d093f7": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "a272d34c-04af-4e15-aa4b-abc844e3c9b6"
+        },
+        "b37a46a0-e07e-45ef-87df-bfcbf5f5bf8e": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "2a3e1f15-90f2-4be5-bb89-f13b865e6b5b"
+        },
+        "bf768b4b-3c62-4f52-ac68-910ef1896730": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "1d74f2f6-ff3a-4940-bdb8-0ca5767dee6a"
+        },
+        "e63a42e9-c280-4bc3-bf38-968baa5264c1": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "b72aca52-6edd-485e-b4b1-bfb35f22b5de"
+        },
+        "e7483de8-0fee-46dc-a2d6-76e13d0a4a35": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "00537ab8-a132-47c3-af9e-0bbe1d7ad8d9"
+        },
+        "ea132ec2-ccad-48a6-8121-3aab161d5867": {
+            "gate": "8b37ffd7-19c3-4541-a02b-ffc0463e9755",
+            "pin": "f0dce350-e975-4700-bc8d-e75c80227ef0"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "adc",
+        "ic",
+        "quad",
+        "spi",
+        "tssop-14"
+    ],
+    "type": "part",
+    "uuid": "cdf7195a-0325-4e4a-859e-02f5475d6165",
+    "value": [
+        false,
+        "MCP3004"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3008-I_P.json
+++ b/parts/ic/adc/microchip/MCP3008-I_P.json
@@ -1,0 +1,104 @@
+{
+    "MPN": [
+        false,
+        "MCP3008-I/P"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21295d.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, 8-Channel ADC"
+    ],
+    "entity": "981606c2-4943-49bd-86b4-db4bc46f6810",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "374572a8-8482-44cb-bfcb-168cabcaae69",
+    "pad_map": {
+        "02063fa6-c325-4df2-bb77-571f28da4f89": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "69f89ca5-fc7f-4f84-a185-4706e8aa539f"
+        },
+        "0a535e6a-5ec6-48f2-b396-9a7236b3ecbe": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "0c514bf9-1433-4259-a880-aeaa79159d08"
+        },
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "f248316d-5cc7-4180-8a28-c539555bfe60"
+        },
+        "275abe84-d886-4feb-af6a-d5fa6101ba48": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "f37a95bf-624b-4cd2-9c29-cddb19c4cd40"
+        },
+        "3017a6d8-6776-4de6-b346-c61951df3f33": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "8cb1ac67-564a-4fe4-8e17-da2174b5a0eb"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "eaf24698-e6e1-45d9-b1d1-58971a79651d"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "91c87d45-5eda-43cc-9988-57213bc701cc"
+        },
+        "61358d72-c4c1-40dd-b6a0-d76c00b07a26": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "d985d896-12cd-40e4-82ac-64dc2025eb64"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "9e1d42b7-8f0e-4078-b0f3-e637fa76db42"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "7b813fa4-3e82-46ba-838e-b579981cbe55"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "33943549-7bf7-4510-bb97-a62096367cfe"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "97723d65-e642-4a9f-ade5-c6ab068124fa"
+        },
+        "89289608-e62d-4f74-aafc-7b459044667b": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "c780ee73-b755-4e23-a987-44d38f2ebe8c"
+        },
+        "b046fe6b-b418-4005-b94b-c515a20b9530": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "9a9ca4ef-9dfb-4e1b-9093-6a748c703840"
+        },
+        "d98636bf-d6ba-4e68-a0ac-3e808e132bc2": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "028381d3-c91e-4356-9c44-632e73d1a551"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "2a28bc18-e5b6-4126-be2a-60a1ac081ddb"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "8-channel",
+        "adc",
+        "dip-16",
+        "ic",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "31e34e2f-3627-4480-a239-e4ffd65c863f",
+    "value": [
+        false,
+        "MCP3008"
+    ]
+}

--- a/parts/ic/adc/microchip/MCP3008-I_SL.json
+++ b/parts/ic/adc/microchip/MCP3008-I_SL.json
@@ -1,0 +1,104 @@
+{
+    "MPN": [
+        false,
+        "MCP3008-I/SL"
+    ],
+    "datasheet": [
+        false,
+        "https://ww1.microchip.com/downloads/en/DeviceDoc/21295d.pdf"
+    ],
+    "description": [
+        false,
+        "10-Bit, 200kSPS, 8-Channel ADC"
+    ],
+    "entity": "981606c2-4943-49bd-86b4-db4bc46f6810",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Microchip"
+    ],
+    "model": "9a0026d7-be20-4450-a466-94c4e77d536d",
+    "package": "28245e4c-ffe9-4461-b663-b43a495e068c",
+    "pad_map": {
+        "150ac7fa-7f46-49f2-ab10-8c0f447d0bd4": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "91c87d45-5eda-43cc-9988-57213bc701cc"
+        },
+        "29845fb8-d37b-4a23-a456-3897cba0240e": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "2a28bc18-e5b6-4126-be2a-60a1ac081ddb"
+        },
+        "32350e73-3524-4259-aad9-74a372ee42e5": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "d985d896-12cd-40e4-82ac-64dc2025eb64"
+        },
+        "327e4032-c988-4b9b-8944-cd6e4257ca8e": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "97723d65-e642-4a9f-ade5-c6ab068124fa"
+        },
+        "38f25dfc-b2f4-4515-83fb-f63c0c529fc9": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "0c514bf9-1433-4259-a880-aeaa79159d08"
+        },
+        "6de88445-a438-452d-9a56-ca754d9c97f8": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "c780ee73-b755-4e23-a987-44d38f2ebe8c"
+        },
+        "6ed9ccb5-ed6a-42a3-9783-7667d4dd997a": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "028381d3-c91e-4356-9c44-632e73d1a551"
+        },
+        "71284ebf-b339-4f0d-bd5f-765d1eb04896": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "f248316d-5cc7-4180-8a28-c539555bfe60"
+        },
+        "7b4e112f-ab67-4389-b475-7c491f95b444": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "f37a95bf-624b-4cd2-9c29-cddb19c4cd40"
+        },
+        "7d774933-233f-42d6-aa61-645fccad511f": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "69f89ca5-fc7f-4f84-a185-4706e8aa539f"
+        },
+        "7e3e50d4-f9a5-4b8d-80bb-9c119b9c88ed": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "33943549-7bf7-4510-bb97-a62096367cfe"
+        },
+        "8a7ba3f8-c2ff-4736-a7af-63bc6b28775a": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "8cb1ac67-564a-4fe4-8e17-da2174b5a0eb"
+        },
+        "ce8e0ff3-c8cb-430b-b47d-4f16d58bb7f3": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "9a9ca4ef-9dfb-4e1b-9093-6a748c703840"
+        },
+        "cf3a38df-5ed7-47dd-84ce-0f9d0a0ba9d1": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "eaf24698-e6e1-45d9-b1d1-58971a79651d"
+        },
+        "d86bca97-5554-479a-8512-843a86f676e5": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "9e1d42b7-8f0e-4078-b0f3-e637fa76db42"
+        },
+        "dd326f38-d93c-4563-a442-d5334a8426d3": {
+            "gate": "37a9ad40-2150-4167-b7b9-0de630974751",
+            "pin": "7b813fa4-3e82-46ba-838e-b579981cbe55"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "10-bit",
+        "8-channel",
+        "adc",
+        "ic",
+        "soic-16",
+        "spi"
+    ],
+    "type": "part",
+    "uuid": "0f27a99d-3028-4200-b3bf-b13f71074e8a",
+    "value": [
+        false,
+        "MCP3008"
+    ]
+}

--- a/symbols/ic/adc/microchip/MCP3001.json
+++ b/symbols/ic/adc/microchip/MCP3001.json
@@ -1,0 +1,381 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "0b981f38-4563-4d19-89cb-a178771c5901": {
+            "position": [
+                -8750000,
+                10000000
+            ]
+        },
+        "23fd4cab-0c3e-4d31-9b36-a059ca34ca24": {
+            "position": [
+                8750000,
+                10000000
+            ]
+        },
+        "53adb50b-08a5-4318-b9b7-75fa3a368e15": {
+            "position": [
+                8750000,
+                -10000000
+            ]
+        },
+        "f5ccc8e5-b689-480b-9d45-5afbad837555": {
+            "position": [
+                -8750000,
+                -10000000
+            ]
+        }
+    },
+    "lines": {
+        "58a2ab4c-5d9a-4f30-ac25-fca8e9393363": {
+            "from": "f5ccc8e5-b689-480b-9d45-5afbad837555",
+            "layer": 0,
+            "to": "0b981f38-4563-4d19-89cb-a178771c5901",
+            "width": 0
+        },
+        "8a8ab334-169e-470c-a399-4d553e6b41a2": {
+            "from": "0b981f38-4563-4d19-89cb-a178771c5901",
+            "layer": 0,
+            "to": "23fd4cab-0c3e-4d31-9b36-a059ca34ca24",
+            "width": 0
+        },
+        "8bf03f81-c777-48fa-b75a-9c2090bef266": {
+            "from": "23fd4cab-0c3e-4d31-9b36-a059ca34ca24",
+            "layer": 0,
+            "to": "53adb50b-08a5-4318-b9b7-75fa3a368e15",
+            "width": 0
+        },
+        "b271cd46-da8e-452a-aea7-18951f29233c": {
+            "from": "53adb50b-08a5-4318-b9b7-75fa3a368e15",
+            "layer": 0,
+            "to": "f5ccc8e5-b689-480b-9d45-5afbad837555",
+            "width": 0
+        }
+    },
+    "name": "MCP3001",
+    "pins": {
+        "17a5f2b7-f0b6-495d-8d1f-ad2d5ccb1e61": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -11250000,
+                0
+            ]
+        },
+        "4ca0fa3e-5568-4af6-a463-17a33b970964": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -11250000,
+                -5000000
+            ]
+        },
+        "6f9bd078-4fe9-4516-915a-9dd287642e67": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                11250000,
+                0
+            ]
+        },
+        "71c73b6a-0f31-49c1-b83b-fb35b8d5a49f": {
+            "decoration": {
+                "clock": true,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                11250000,
+                5000000
+            ]
+        },
+        "858f46a7-7406-4e51-929b-e7a3955ad374": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -11250000,
+                5000000
+            ]
+        },
+        "a2e867f7-46bc-4b01-9e61-07bb0f8daff3": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                12500000
+            ]
+        },
+        "e3f47dec-5623-49de-bc07-dff14be6576c": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                11250000,
+                -5000000
+            ]
+        },
+        "eedf8571-1aea-430a-a84e-f006a60e414d": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                0,
+                -12500000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {
+        "0m": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2500000,
+                    11250000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2500000,
+                    -11250000
+                ]
+            }
+        },
+        "0n": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2500000,
+                    11250000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2500000,
+                    -11250000
+                ]
+            }
+        },
+        "180m": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2500000,
+                    -11250000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    2500000,
+                    11250000
+                ]
+            }
+        },
+        "180n": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2500000,
+                    -11250000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    2500000,
+                    11250000
+                ]
+            }
+        },
+        "270m": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -10000000,
+                    -7500000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    10000000,
+                    -7500000
+                ]
+            }
+        },
+        "270n": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -10000000,
+                    -7500000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    10000000,
+                    -7500000
+                ]
+            }
+        },
+        "90m": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    10000000,
+                    -7500000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -10000000,
+                    -7500000
+                ]
+            }
+        },
+        "90n": {
+            "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    10000000,
+                    -7500000
+                ]
+            },
+            "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -10000000,
+                    -7500000
+                ]
+            }
+        }
+    },
+    "texts": {
+        "308ffbbb-128e-4a54-8bc6-029e541d48ec": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -10000000,
+                    -7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        },
+        "4c895665-f05a-4d9c-a7a2-2c4447306102": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    10000000,
+                    -7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "23de0c4f-a053-40c1-9204-eab8517b13c5",
+    "uuid": "bd22cd54-f903-43b2-9abc-8597d5347eab"
+}

--- a/symbols/ic/adc/microchip/MCP3002.json
+++ b/symbols/ic/adc/microchip/MCP3002.json
@@ -1,0 +1,381 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "4581ef64-cff3-4f23-bece-41023016e677": {
+            "position": [
+                -12500000,
+                7500000
+            ]
+        },
+        "6f8d2e7b-89ed-4c63-8e1a-8fd10b3bc657": {
+            "position": [
+                -12500000,
+                -7500000
+            ]
+        },
+        "a8e10a0a-0cef-4439-9671-76a82a6bc4e6": {
+            "position": [
+                12500000,
+                7500000
+            ]
+        },
+        "ab1eb15a-fe79-48f2-a723-507992efad1e": {
+            "position": [
+                12500000,
+                -7500000
+            ]
+        }
+    },
+    "lines": {
+        "13f45f5d-5caf-40e9-af83-12f77b33cc7f": {
+            "from": "4581ef64-cff3-4f23-bece-41023016e677",
+            "layer": 0,
+            "to": "a8e10a0a-0cef-4439-9671-76a82a6bc4e6",
+            "width": 0
+        },
+        "2ac74465-4c14-4455-8dc4-7eff08ff6df7": {
+            "from": "6f8d2e7b-89ed-4c63-8e1a-8fd10b3bc657",
+            "layer": 0,
+            "to": "4581ef64-cff3-4f23-bece-41023016e677",
+            "width": 0
+        },
+        "6a382379-b099-4779-b98f-e7acac3de33c": {
+            "from": "ab1eb15a-fe79-48f2-a723-507992efad1e",
+            "layer": 0,
+            "to": "6f8d2e7b-89ed-4c63-8e1a-8fd10b3bc657",
+            "width": 0
+        },
+        "fe455baa-7ea6-4579-abc6-590e64eea670": {
+            "from": "a8e10a0a-0cef-4439-9671-76a82a6bc4e6",
+            "layer": 0,
+            "to": "ab1eb15a-fe79-48f2-a723-507992efad1e",
+            "width": 0
+        }
+    },
+    "name": "MCP3002",
+    "pins": {
+        "108cc5a3-8126-4929-becc-0f3eff07984c": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                0
+            ]
+        },
+        "22e577dc-c37a-479c-bac5-67b33552c432": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                10000000
+            ]
+        },
+        "32cd7fd5-6980-4610-908a-2cfaf151c679": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                -3750000
+            ]
+        },
+        "3635c69a-d0ed-4271-97c1-ee6c2a1da303": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                3750000
+            ]
+        },
+        "72460bec-bfc3-45be-bcef-1ddbf5d8382f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                0,
+                -10000000
+            ]
+        },
+        "9098946b-6826-4f8f-b866-ec4b8a8a4e74": {
+            "decoration": {
+                "clock": true,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                15000000,
+                3750000
+            ]
+        },
+        "afba04ee-2185-4ba1-abc5-bd0bc6aa4590": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                15000000,
+                -3750000
+            ]
+        },
+        "f16f9abf-58b1-485b-a653-6dd990a36994": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                15000000,
+                0
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {
+        "0m": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -8750000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    8750000
+                ]
+            }
+        },
+        "0n": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -8750000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    8750000
+                ]
+            }
+        },
+        "180m": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    7500000,
+                    8750000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -8750000
+                ]
+            }
+        },
+        "180n": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    7500000,
+                    8750000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -8750000
+                ]
+            }
+        },
+        "270m": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    13750000,
+                    -5000000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -13750000,
+                    -5000000
+                ]
+            }
+        },
+        "270n": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    13750000,
+                    -5000000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -13750000,
+                    -5000000
+                ]
+            }
+        },
+        "90m": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 49152,
+                "mirror": true,
+                "shift": [
+                    -13750000,
+                    6250000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    13750000,
+                    6250000
+                ]
+            }
+        },
+        "90n": {
+            "8963a27c-4887-493b-990c-a5249fb8c173": {
+                "angle": 49152,
+                "mirror": true,
+                "shift": [
+                    -13750000,
+                    6250000
+                ]
+            },
+            "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    13750000,
+                    6250000
+                ]
+            }
+        }
+    },
+    "texts": {
+        "8963a27c-4887-493b-990c-a5249fb8c173": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    13750000,
+                    -5000000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        },
+        "fe5f50d2-226c-4921-af8b-f75613db61ff": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -13750000,
+                    -5000000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "411f6247-d754-409b-a1e6-ed09006e87a3",
+    "uuid": "06339841-25de-41d3-bbd7-a17cf8a78f80"
+}

--- a/symbols/ic/adc/microchip/MCP3004.json
+++ b/symbols/ic/adc/microchip/MCP3004.json
@@ -1,0 +1,449 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "44ae227e-f850-4f42-b1b2-7046bfd98c61": {
+            "position": [
+                -10000000,
+                15000000
+            ]
+        },
+        "768d8779-ea6f-40fe-8a76-ea6328ba2d9b": {
+            "position": [
+                10000000,
+                15000000
+            ]
+        },
+        "8d59fdb3-fee1-46d5-a3f9-eb5d955f5f06": {
+            "position": [
+                10000000,
+                -15000000
+            ]
+        },
+        "be086bc5-150e-4e1d-b0b2-6eaf2346800c": {
+            "position": [
+                -10000000,
+                -15000000
+            ]
+        }
+    },
+    "lines": {
+        "170bd992-25ff-432b-be13-819074eaf94b": {
+            "from": "768d8779-ea6f-40fe-8a76-ea6328ba2d9b",
+            "layer": 0,
+            "to": "8d59fdb3-fee1-46d5-a3f9-eb5d955f5f06",
+            "width": 0
+        },
+        "7d44f4d4-c030-46dd-aa17-f8552b5151eb": {
+            "from": "be086bc5-150e-4e1d-b0b2-6eaf2346800c",
+            "layer": 0,
+            "to": "44ae227e-f850-4f42-b1b2-7046bfd98c61",
+            "width": 0
+        },
+        "a3727a7f-86dd-42bc-99f8-771ea0d4f121": {
+            "from": "8d59fdb3-fee1-46d5-a3f9-eb5d955f5f06",
+            "layer": 0,
+            "to": "be086bc5-150e-4e1d-b0b2-6eaf2346800c",
+            "width": 0
+        },
+        "b9b120ac-3fff-4211-ab20-edb28f4193ce": {
+            "from": "44ae227e-f850-4f42-b1b2-7046bfd98c61",
+            "layer": 0,
+            "to": "768d8779-ea6f-40fe-8a76-ea6328ba2d9b",
+            "width": 0
+        }
+    },
+    "name": "MCP3004",
+    "pins": {
+        "00537ab8-a132-47c3-af9e-0bbe1d7ad8d9": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                11250000
+            ]
+        },
+        "1d74f2f6-ff3a-4940-bdb8-0ca5767dee6a": {
+            "decoration": {
+                "clock": true,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                6250000
+            ]
+        },
+        "2a3e1f15-90f2-4be5-bb89-f13b865e6b5b": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                -1250000
+            ]
+        },
+        "662d9dd0-bb47-4e15-a1c3-bde4d0d24810": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                8750000
+            ]
+        },
+        "766777bc-83c4-445c-8ae9-74b73ed357b0": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                17500000
+            ]
+        },
+        "96841b5d-2763-4543-b796-d1ef7bb8e52a": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                -10000000
+            ]
+        },
+        "a272d34c-04af-4e15-aa4b-abc844e3c9b6": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                6250000,
+                -17500000
+            ]
+        },
+        "b72aca52-6edd-485e-b4b1-bfb35f22b5de": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                3750000
+            ]
+        },
+        "c5f70843-f219-4460-b980-4c2e7828cbe3": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                0
+            ]
+        },
+        "f0dce350-e975-4700-bc8d-e75c80227ef0": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                -5000000
+            ]
+        },
+        "fb22bccd-38ab-4e67-a728-883f6d4edf74": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                -6250000
+            ]
+        },
+        "fbd4ff3a-ee52-4a3f-a5b8-22f1db44df60": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -5000000,
+                -17500000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {
+        "0m": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    16250000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -16250000
+                ]
+            }
+        },
+        "0n": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    16250000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -16250000
+                ]
+            }
+        },
+        "180m": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -16250000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    7500000,
+                    16250000
+                ]
+            }
+        },
+        "180n": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    7500000,
+                    -16250000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    7500000,
+                    16250000
+                ]
+            }
+        },
+        "270m": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -12500000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    11250000,
+                    -12500000
+                ]
+            }
+        },
+        "270n": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -12500000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    11250000,
+                    -12500000
+                ]
+            }
+        },
+        "90m": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    11250000,
+                    -12500000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -12500000
+                ]
+            }
+        },
+        "90n": {
+            "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    11250000,
+                    -12500000
+                ]
+            },
+            "e07db475-3241-4210-935b-de17b2cecd0a": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -12500000
+                ]
+            }
+        }
+    },
+    "texts": {
+        "c84df194-df78-4fab-9232-97d8a9ab54ed": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -12500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        },
+        "e07db475-3241-4210-935b-de17b2cecd0a": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    11250000,
+                    -12500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "70aa1b25-35fe-4b4c-a1d2-ca14ba3192df",
+    "uuid": "20d335a9-3b98-4a26-a43d-2d9b5617794a"
+}

--- a/symbols/ic/adc/microchip/MCP3008.json
+++ b/symbols/ic/adc/microchip/MCP3008.json
@@ -1,0 +1,517 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "68852244-e5d2-431e-9701-f35cb3e2a037": {
+            "position": [
+                -10000000,
+                -18750000
+            ]
+        },
+        "70cdd12e-cad6-4ac8-80df-27462ed17d40": {
+            "position": [
+                10000000,
+                18750000
+            ]
+        },
+        "888bf96c-b7fa-49e9-9298-37bfbf6aa612": {
+            "position": [
+                10000000,
+                -18750000
+            ]
+        },
+        "a13d3a0b-6d57-4ff9-a5a0-dd7c902bfc29": {
+            "position": [
+                -10000000,
+                18750000
+            ]
+        }
+    },
+    "lines": {
+        "2218459d-6831-49e1-87a8-f99dee037c27": {
+            "from": "a13d3a0b-6d57-4ff9-a5a0-dd7c902bfc29",
+            "layer": 0,
+            "to": "70cdd12e-cad6-4ac8-80df-27462ed17d40",
+            "width": 0
+        },
+        "32493878-68cb-4808-ae80-b88ba46ae25f": {
+            "from": "888bf96c-b7fa-49e9-9298-37bfbf6aa612",
+            "layer": 0,
+            "to": "68852244-e5d2-431e-9701-f35cb3e2a037",
+            "width": 0
+        },
+        "5cd0fac1-41ee-4e41-8b82-c39253f91056": {
+            "from": "68852244-e5d2-431e-9701-f35cb3e2a037",
+            "layer": 0,
+            "to": "a13d3a0b-6d57-4ff9-a5a0-dd7c902bfc29",
+            "width": 0
+        },
+        "618f454c-e0ed-4cf0-bcc8-f963e74739af": {
+            "from": "70cdd12e-cad6-4ac8-80df-27462ed17d40",
+            "layer": 0,
+            "to": "888bf96c-b7fa-49e9-9298-37bfbf6aa612",
+            "width": 0
+        }
+    },
+    "name": "MCP3008",
+    "pins": {
+        "028381d3-c91e-4356-9c44-632e73d1a551": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                21250000
+            ]
+        },
+        "0c514bf9-1433-4259-a880-aeaa79159d08": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                3750000,
+                -21250000
+            ]
+        },
+        "2a28bc18-e5b6-4126-be2a-60a1ac081ddb": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                5000000
+            ]
+        },
+        "33943549-7bf7-4510-bb97-a62096367cfe": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                1250000
+            ]
+        },
+        "69f89ca5-fc7f-4f84-a185-4706e8aa539f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                -2500000
+            ]
+        },
+        "7b813fa4-3e82-46ba-838e-b579981cbe55": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                -13750000
+            ]
+        },
+        "8cb1ac67-564a-4fe4-8e17-da2174b5a0eb": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -3750000,
+                -21250000
+            ]
+        },
+        "91c87d45-5eda-43cc-9988-57213bc701cc": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                -2500000
+            ]
+        },
+        "97723d65-e642-4a9f-ade5-c6ab068124fa": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                12500000
+            ]
+        },
+        "9a9ca4ef-9dfb-4e1b-9093-6a748c703840": {
+            "decoration": {
+                "clock": true,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                12500000
+            ]
+        },
+        "9e1d42b7-8f0e-4078-b0f3-e637fa76db42": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                -10000000
+            ]
+        },
+        "c780ee73-b755-4e23-a987-44d38f2ebe8c": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                -6250000
+            ]
+        },
+        "d985d896-12cd-40e4-82ac-64dc2025eb64": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                -13750000
+            ]
+        },
+        "eaf24698-e6e1-45d9-b1d1-58971a79651d": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                8750000
+            ]
+        },
+        "f248316d-5cc7-4180-8a28-c539555bfe60": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -12500000,
+                -6250000
+            ]
+        },
+        "f37a95bf-624b-4cd2-9c29-cddb19c4cd40": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                12500000,
+                5000000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {
+        "0m": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    6250000,
+                    -20000000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    6250000,
+                    20000000
+                ]
+            }
+        },
+        "0n": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    6250000,
+                    -20000000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    6250000,
+                    20000000
+                ]
+            }
+        },
+        "180m": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    6250000,
+                    20000000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    6250000,
+                    -20000000
+                ]
+            }
+        },
+        "180n": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    6250000,
+                    20000000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    6250000,
+                    -20000000
+                ]
+            }
+        },
+        "270m": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    11250000,
+                    -16250000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -16250000
+                ]
+            }
+        },
+        "270n": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    11250000,
+                    -16250000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -16250000
+                ]
+            }
+        },
+        "90m": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -16250000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    11250000,
+                    -16250000
+                ]
+            }
+        },
+        "90n": {
+            "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -16250000
+                ]
+            },
+            "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    11250000,
+                    -16250000
+                ]
+            }
+        }
+    },
+    "texts": {
+        "675443a6-2cb1-43e8-99a5-6596a217a1c7": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    11250000,
+                    -16250000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        },
+        "cc8df633-ad4b-4294-b53d-f8d276dcff2b": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -11250000,
+                    -16250000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "7f8202ae-efad-4b06-8d44-ff5f79df3a0e",
+    "uuid": "0922327b-cc0d-4640-bc97-d72586445c22"
+}

--- a/units/ic/adc/microchip/MCP3001.json
+++ b/units/ic/adc/microchip/MCP3001.json
@@ -1,0 +1,56 @@
+{
+    "manufacturer": "Microchip",
+    "name": "MCP3001",
+    "pins": {
+        "17a5f2b7-f0b6-495d-8d1f-ad2d5ccb1e61": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "In+",
+            "swap_group": 0
+        },
+        "4ca0fa3e-5568-4af6-a463-17a33b970964": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "In-",
+            "swap_group": 0
+        },
+        "6f9bd078-4fe9-4516-915a-9dd287642e67": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "Dout",
+            "swap_group": 0
+        },
+        "71c73b6a-0f31-49c1-b83b-fb35b8d5a49f": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CLK",
+            "swap_group": 0
+        },
+        "858f46a7-7406-4e51-929b-e7a3955ad374": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "Vref",
+            "swap_group": 0
+        },
+        "a2e867f7-46bc-4b01-9e61-07bb0f8daff3": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "Vdd",
+            "swap_group": 0
+        },
+        "e3f47dec-5623-49de-bc07-dff14be6576c": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CS/SHDN",
+            "swap_group": 0
+        },
+        "eedf8571-1aea-430a-a84e-f006a60e414d": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vss",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "23de0c4f-a053-40c1-9204-eab8517b13c5"
+}

--- a/units/ic/adc/microchip/MCP3002.json
+++ b/units/ic/adc/microchip/MCP3002.json
@@ -1,0 +1,56 @@
+{
+    "manufacturer": "Microchip",
+    "name": "MCP3002",
+    "pins": {
+        "108cc5a3-8126-4929-becc-0f3eff07984c": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH0",
+            "swap_group": 0
+        },
+        "22e577dc-c37a-479c-bac5-67b33552c432": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vdd/Vref",
+            "swap_group": 0
+        },
+        "32cd7fd5-6980-4610-908a-2cfaf151c679": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH1",
+            "swap_group": 0
+        },
+        "3635c69a-d0ed-4271-97c1-ee6c2a1da303": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CS/SHDN",
+            "swap_group": 0
+        },
+        "72460bec-bfc3-45be-bcef-1ddbf5d8382f": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vss",
+            "swap_group": 0
+        },
+        "9098946b-6826-4f8f-b866-ec4b8a8a4e74": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CLK",
+            "swap_group": 0
+        },
+        "afba04ee-2185-4ba1-abc5-bd0bc6aa4590": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "Din",
+            "swap_group": 0
+        },
+        "f16f9abf-58b1-485b-a653-6dd990a36994": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "Dout",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "411f6247-d754-409b-a1e6-ed09006e87a3"
+}

--- a/units/ic/adc/microchip/MCP3004.json
+++ b/units/ic/adc/microchip/MCP3004.json
@@ -1,0 +1,80 @@
+{
+    "manufacturer": "Microchip",
+    "name": "MCP3004",
+    "pins": {
+        "00537ab8-a132-47c3-af9e-0bbe1d7ad8d9": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "Vref",
+            "swap_group": 0
+        },
+        "1d74f2f6-ff3a-4940-bdb8-0ca5767dee6a": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CLK",
+            "swap_group": 0
+        },
+        "2a3e1f15-90f2-4be5-bb89-f13b865e6b5b": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH2",
+            "swap_group": 0
+        },
+        "662d9dd0-bb47-4e15-a1c3-bde4d0d24810": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH0",
+            "swap_group": 0
+        },
+        "766777bc-83c4-445c-8ae9-74b73ed357b0": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vdd",
+            "swap_group": 0
+        },
+        "96841b5d-2763-4543-b796-d1ef7bb8e52a": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CS/SHDN",
+            "swap_group": 0
+        },
+        "a272d34c-04af-4e15-aa4b-abc844e3c9b6": {
+            "direction": "passive",
+            "names": [],
+            "primary_name": "DGND",
+            "swap_group": 0
+        },
+        "b72aca52-6edd-485e-b4b1-bfb35f22b5de": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH1",
+            "swap_group": 0
+        },
+        "c5f70843-f219-4460-b980-4c2e7828cbe3": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "Dout",
+            "swap_group": 0
+        },
+        "f0dce350-e975-4700-bc8d-e75c80227ef0": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "Din",
+            "swap_group": 0
+        },
+        "fb22bccd-38ab-4e67-a728-883f6d4edf74": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH3",
+            "swap_group": 0
+        },
+        "fbd4ff3a-ee52-4a3f-a5b8-22f1db44df60": {
+            "direction": "passive",
+            "names": [],
+            "primary_name": "AGND",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "70aa1b25-35fe-4b4c-a1d2-ca14ba3192df"
+}

--- a/units/ic/adc/microchip/MCP3008.json
+++ b/units/ic/adc/microchip/MCP3008.json
@@ -1,0 +1,104 @@
+{
+    "manufacturer": "Microchip",
+    "name": "MCP3008",
+    "pins": {
+        "028381d3-c91e-4356-9c44-632e73d1a551": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vdd",
+            "swap_group": 0
+        },
+        "0c514bf9-1433-4259-a880-aeaa79159d08": {
+            "direction": "passive",
+            "names": [],
+            "primary_name": "DGND",
+            "swap_group": 0
+        },
+        "2a28bc18-e5b6-4126-be2a-60a1ac081ddb": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH2",
+            "swap_group": 0
+        },
+        "33943549-7bf7-4510-bb97-a62096367cfe": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH3",
+            "swap_group": 0
+        },
+        "69f89ca5-fc7f-4f84-a185-4706e8aa539f": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "Dout",
+            "swap_group": 0
+        },
+        "7b813fa4-3e82-46ba-838e-b579981cbe55": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH7",
+            "swap_group": 0
+        },
+        "8cb1ac67-564a-4fe4-8e17-da2174b5a0eb": {
+            "direction": "passive",
+            "names": [],
+            "primary_name": "AGND",
+            "swap_group": 0
+        },
+        "91c87d45-5eda-43cc-9988-57213bc701cc": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH4",
+            "swap_group": 0
+        },
+        "97723d65-e642-4a9f-ade5-c6ab068124fa": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH0",
+            "swap_group": 0
+        },
+        "9a9ca4ef-9dfb-4e1b-9093-6a748c703840": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CLK",
+            "swap_group": 0
+        },
+        "9e1d42b7-8f0e-4078-b0f3-e637fa76db42": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH6",
+            "swap_group": 0
+        },
+        "c780ee73-b755-4e23-a987-44d38f2ebe8c": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "Din",
+            "swap_group": 0
+        },
+        "d985d896-12cd-40e4-82ac-64dc2025eb64": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CS/SHDN",
+            "swap_group": 0
+        },
+        "eaf24698-e6e1-45d9-b1d1-58971a79651d": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH1",
+            "swap_group": 0
+        },
+        "f248316d-5cc7-4180-8a28-c539555bfe60": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "CH5",
+            "swap_group": 0
+        },
+        "f37a95bf-624b-4cd2-9c29-cddb19c4cd40": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "Vref",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "7f8202ae-efad-4b06-8d44-ff5f79df3a0e"
+}


### PR DESCRIPTION
This adds the MCP300x ADC series by microchip. More specifically:
- 1-Channel ADC [MCP3001](https://www.microchip.com/wwwproducts/en/MCP3001)
- 2-Channel ADC [MCP3002](https://www.microchip.com/wwwproducts/en/MCP3002)
- 4-Channel ADC [MCP3004](https://www.microchip.com/wwwproducts/en/MCP3004)
- 8-Channel ADC [MCP3008](https://www.microchip.com/wwwproducts/en/MCP3008)

Notes:
- I skipped one MCP3001 variant with MSOP package because I was lazy
- I reused the SOIC-16 package also present added #114 