### PR TITLE
Add Highly PB6149L LED illuminated push switches

### DIFF
--- a/entities/switch/push_switch_spst_off-on_4_pins_w_antiparallel_bicolor_led.json
+++ b/entities/switch/push_switch_spst_off-on_4_pins_w_antiparallel_bicolor_led.json
@@ -1,0 +1,29 @@
+{
+    "gates": {
+        "77d0364f-fb9a-4c49-8591-a7aacabc48a7": {
+            "name": "Switch",
+            "suffix": "SW",
+            "swap_group": 0,
+            "unit": "ad3f15e4-00db-4102-973b-0d44fb9cb294"
+        },
+        "df610c11-99c6-4cd2-b025-64440002187d": {
+            "name": "LED",
+            "suffix": "D",
+            "swap_group": 0,
+            "unit": "454c6b10-5bca-481e-a7e8-5da92961a3d9"
+        }
+    },
+    "manufacturer": "",
+    "name": "Push Switch SPST Off-On (4 pins, with antiparallel bicolor LED)",
+    "prefix": "SW",
+    "tags": [
+        "4-pin",
+        "bicolor",
+        "led",
+        "push",
+        "spst",
+        "switch"
+    ],
+    "type": "entity",
+    "uuid": "21cee5dc-1474-4d88-8d49-7cf951837c32"
+}

--- a/entities/switch/push_switch_spst_off-on_4_pins_w_led.json
+++ b/entities/switch/push_switch_spst_off-on_4_pins_w_led.json
@@ -1,0 +1,28 @@
+{
+    "gates": {
+        "5ff7ac8f-718d-436c-9d39-80f38d2b1363": {
+            "name": "LED",
+            "suffix": "LED",
+            "swap_group": 0,
+            "unit": "40746e42-5a30-481e-b342-ae7547413c03"
+        },
+        "77d0364f-fb9a-4c49-8591-a7aacabc48a7": {
+            "name": "Switch",
+            "suffix": "SW",
+            "swap_group": 0,
+            "unit": "ad3f15e4-00db-4102-973b-0d44fb9cb294"
+        }
+    },
+    "manufacturer": "",
+    "name": "Push Switch SPST Off-On (4 pins, with LED)",
+    "prefix": "SW",
+    "tags": [
+        "4-pin",
+        "led",
+        "push",
+        "spst",
+        "switch"
+    ],
+    "type": "entity",
+    "uuid": "50dd24ff-3133-47bb-beec-89dd92e23889"
+}

--- a/packages/mechanical/switch/highly/pb614/package.json
+++ b/packages/mechanical/switch/highly/pb614/package.json
@@ -1,0 +1,408 @@
+{
+    "arcs": {},
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "dimensions": {},
+    "junctions": {
+        "2916326f-be2a-4bb5-aec7-19e32d6e0b72": {
+            "position": [
+                -3860000,
+                -3700000
+            ]
+        },
+        "4aa95e1b-42e5-4cda-8dc0-cfdea958cace": {
+            "position": [
+                3860000,
+                -3700000
+            ]
+        },
+        "78d0a44d-409f-4974-8e9d-ca8c7274a8ef": {
+            "position": [
+                3860000,
+                3700000
+            ]
+        },
+        "c85ff004-39ca-42e7-a223-11be32fc873d": {
+            "position": [
+                -3100000,
+                3700000
+            ]
+        },
+        "de10c582-7f94-401f-82a2-b8f86c5dcf4c": {
+            "position": [
+                -3875000,
+                2945000
+            ]
+        }
+    },
+    "keepouts": {},
+    "lines": {
+        "21720464-cbf4-47e2-8911-c2e9d81f0958": {
+            "from": "4aa95e1b-42e5-4cda-8dc0-cfdea958cace",
+            "layer": 20,
+            "to": "2916326f-be2a-4bb5-aec7-19e32d6e0b72",
+            "width": 150000
+        },
+        "5ce41b4b-4299-4684-b2e2-e6d89b1e307a": {
+            "from": "c85ff004-39ca-42e7-a223-11be32fc873d",
+            "layer": 20,
+            "to": "78d0a44d-409f-4974-8e9d-ca8c7274a8ef",
+            "width": 150000
+        },
+        "b01f5411-9fb7-4564-8af2-2e03ab006566": {
+            "from": "2916326f-be2a-4bb5-aec7-19e32d6e0b72",
+            "layer": 20,
+            "to": "de10c582-7f94-401f-82a2-b8f86c5dcf4c",
+            "width": 150000
+        },
+        "b601fd45-786f-49ae-907a-8a56b7cde76f": {
+            "from": "78d0a44d-409f-4974-8e9d-ca8c7274a8ef",
+            "layer": 20,
+            "to": "4aa95e1b-42e5-4cda-8dc0-cfdea958cace",
+            "width": 150000
+        },
+        "ec28e196-ec01-4bca-988f-816f40b4c35d": {
+            "from": "de10c582-7f94-401f-82a2-b8f86c5dcf4c",
+            "layer": 20,
+            "to": "c85ff004-39ca-42e7-a223-11be32fc873d",
+            "width": 150000
+        }
+    },
+    "manufacturer": "Highly Electric",
+    "models": {},
+    "name": "PB614",
+    "pads": {
+        "0c63d4d0-7aca-481a-a643-44811b571eea": {
+            "name": "K",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 1000000,
+                "pad_diameter": 1200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2700000,
+                    0
+                ]
+            }
+        },
+        "16dfdb65-dd3b-48e9-b035-5156b3616917": {
+            "name": "1",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 1000000,
+                "pad_diameter": 1200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2540000,
+                    2540000
+                ]
+            }
+        },
+        "2bc9c38a-6bbf-45df-b04d-55fcb83a77e7": {
+            "name": "4",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 1000000,
+                "pad_diameter": 1200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2540000,
+                    -2540000
+                ]
+            }
+        },
+        "a6e906c2-2586-4ed8-8b02-1e1b4ba40f38": {
+            "name": "2",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 1000000,
+                "pad_diameter": 1200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2540000,
+                    2540000
+                ]
+            }
+        },
+        "c09fbaef-2401-493f-8b5f-e049bc484a68": {
+            "name": "3",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 1000000,
+                "pad_diameter": 1200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2540000,
+                    -2540000
+                ]
+            }
+        },
+        "fe6b0a55-1954-464e-b607-74bef28df8c6": {
+            "name": "A",
+            "padstack": "296cf69b-9d53-45e4-aaab-4aedf4087d3a",
+            "parameter_set": {
+                "hole_diameter": 1000000,
+                "pad_diameter": 1200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    0
+                ]
+            }
+        }
+    },
+    "parameter_program": "6.600mm 6.280mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "9d65d6b2-4c5a-4649-8176-fb7e494fd54f": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3100000,
+                        -3100000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3100000,
+                        2100000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2100000,
+                        3100000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3100000,
+                        3100000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3100000,
+                        -3100000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "b2b6901c-e91d-420d-a380-a6cef1f12a9f": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3550000,
+                        -3390000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3550000,
+                        3390000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3550000,
+                        3390000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3550000,
+                        -3390000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "d1e9696b-0439-435b-922a-e225d2a1ccd7": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3100000,
+                        -3100000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3100000,
+                        3100000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3100000,
+                        3100000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3100000,
+                        -3100000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "rules": {
+        "clearance_package": {
+            "clearance_silkscreen_cu": 200000,
+            "clearance_silkscreen_pkg": 200000,
+            "enabled": true,
+            "order": -1
+        },
+        "package_checks": {
+            "enabled": true,
+            "order": -1
+        }
+    },
+    "tags": [
+        "bicolor",
+        "button",
+        "led",
+        "push",
+        "switch"
+    ],
+    "texts": {
+        "07e03cca-ae62-460a-96e0-8263d6706c71": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2700000,
+                    0
+                ]
+            },
+            "size": 1200000,
+            "text": "$RD",
+            "width": 0
+        },
+        "cf224db2-01ca-469e-97a7-f5c1c424944a": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4030000,
+                    4650000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        }
+    },
+    "type": "package",
+    "uuid": "8397e560-8cbd-4b14-b2a6-0bf40899b3dd"
+}

--- a/parts/mechanical/switch/highly/PB6149L-1.json
+++ b/parts/mechanical/switch/highly/PB6149L-1.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-1"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with red LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "red"
+    ],
+    "type": "part",
+    "uuid": "792e9d9e-c43c-499d-b61f-d4f96e340134",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-10.json
+++ b/parts/mechanical/switch/highly/PB6149L-10.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-10"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with pink LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "pink"
+    ],
+    "type": "part",
+    "uuid": "8201196e-837b-4fee-9c97-d7bcb1f21c46",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-11.json
+++ b/parts/mechanical/switch/highly/PB6149L-11.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-11"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with purple LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "purple"
+    ],
+    "type": "part",
+    "uuid": "bb0a89f0-da1b-4b74-a24b-16b5eb407099",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-12.json
+++ b/parts/mechanical/switch/highly/PB6149L-12.json
@@ -1,0 +1,33 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-12"
+    ],
+    "base": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with (red/yellow) bicolor LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "red",
+        "yellow"
+    ],
+    "type": "part",
+    "uuid": "c68f1b6f-0131-4f48-aada-3c01de640fa1",
+    "value": [
+        true,
+        "PB6149L"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-13.json
+++ b/parts/mechanical/switch/highly/PB6149L-13.json
@@ -1,0 +1,33 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-13"
+    ],
+    "base": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with (red/green) bicolor LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "green",
+        "red"
+    ],
+    "type": "part",
+    "uuid": "a42029ad-1ca6-4d49-b186-59a34cf3b03d",
+    "value": [
+        true,
+        "PB6149L"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-14.json
+++ b/parts/mechanical/switch/highly/PB6149L-14.json
@@ -1,0 +1,33 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-14"
+    ],
+    "base": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with (red/blue) bicolor LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "blue",
+        "red"
+    ],
+    "type": "part",
+    "uuid": "42e2d064-d727-4c9f-b24c-126efa78a014",
+    "value": [
+        true,
+        "PB6149L"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-2.json
+++ b/parts/mechanical/switch/highly/PB6149L-2.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-2"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with yellow LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "yellow"
+    ],
+    "type": "part",
+    "uuid": "b914ff81-dbfb-4d72-9ba2-633c734e8282",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-23.json
+++ b/parts/mechanical/switch/highly/PB6149L-23.json
@@ -1,0 +1,33 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-23"
+    ],
+    "base": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with (yellow/green) bicolor LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "green",
+        "yellow"
+    ],
+    "type": "part",
+    "uuid": "987eae30-82ac-4729-a411-5c9db655892a",
+    "value": [
+        true,
+        "PB6149L"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-3.json
+++ b/parts/mechanical/switch/highly/PB6149L-3.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-3"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with green LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "green"
+    ],
+    "type": "part",
+    "uuid": "ebecd961-25c9-4274-ab9c-8fbf0991c420",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-4.json
+++ b/parts/mechanical/switch/highly/PB6149L-4.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-4"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with blue LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "blue"
+    ],
+    "type": "part",
+    "uuid": "a981ff9c-e6a5-4a00-96ea-9ae584902f8b",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-48.json
+++ b/parts/mechanical/switch/highly/PB6149L-48.json
@@ -1,0 +1,33 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-48"
+    ],
+    "base": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with (blue/amber) bicolor LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "amber",
+        "blue"
+    ],
+    "type": "part",
+    "uuid": "ca2fc855-ba7b-43e7-8495-e795ffc63b4f",
+    "value": [
+        true,
+        "PB6149L"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-5.json
+++ b/parts/mechanical/switch/highly/PB6149L-5.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-5"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with white LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "white"
+    ],
+    "type": "part",
+    "uuid": "b6563efe-a257-4cad-9e7d-5a8b612b1887",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-52.json
+++ b/parts/mechanical/switch/highly/PB6149L-52.json
@@ -1,0 +1,33 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-52"
+    ],
+    "base": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with (white/yellow) bicolor LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "white",
+        "yellow"
+    ],
+    "type": "part",
+    "uuid": "77d74a99-edd5-401d-9b7c-ed3137a653d8",
+    "value": [
+        true,
+        "PB6149L"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-58.json
+++ b/parts/mechanical/switch/highly/PB6149L-58.json
@@ -1,0 +1,33 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-58"
+    ],
+    "base": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with (white/amber) bicolor LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "amber",
+        "white"
+    ],
+    "type": "part",
+    "uuid": "ec99187c-2aaa-4b02-b76b-dcd8b2d71947",
+    "value": [
+        true,
+        "PB6149L"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-6.json
+++ b/parts/mechanical/switch/highly/PB6149L-6.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-6"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with pure green LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "green"
+    ],
+    "type": "part",
+    "uuid": "e69571b3-d3d8-47c0-a8c4-9f7b2ae021bf",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-8.json
+++ b/parts/mechanical/switch/highly/PB6149L-8.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-8"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with amber LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "amber"
+    ],
+    "type": "part",
+    "uuid": "9c6f0bda-7299-46d5-beac-ceeeb774ca51",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-9.json
+++ b/parts/mechanical/switch/highly/PB6149L-9.json
@@ -1,0 +1,32 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-9"
+    ],
+    "base": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "datasheet": [
+        true,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with blue-green LED"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [
+        "blue-green"
+    ],
+    "type": "part",
+    "uuid": "195989eb-61ca-4298-92c5-b38263e0f817",
+    "value": [
+        true,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-Base-Part.json
+++ b/parts/mechanical/switch/highly/PB6149L-Base-Part.json
@@ -1,0 +1,64 @@
+{
+    "MPN": [
+        false,
+        "PB614-xx (LED, Base Part)"
+    ],
+    "datasheet": [
+        false,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with LED"
+    ],
+    "entity": "50dd24ff-3133-47bb-beec-89dd92e23889",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "8397e560-8cbd-4b14-b2a6-0bf40899b3dd",
+    "pad_map": {
+        "0c63d4d0-7aca-481a-a643-44811b571eea": {
+            "gate": "5ff7ac8f-718d-436c-9d39-80f38d2b1363",
+            "pin": "3c305ca9-14d3-40b4-a365-8938959c043e"
+        },
+        "16dfdb65-dd3b-48e9-b035-5156b3616917": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "97955848-10f4-4667-b838-46f6bb8fe085"
+        },
+        "2bc9c38a-6bbf-45df-b04d-55fcb83a77e7": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "7f275da1-94c1-4a9b-8a2e-bfd4ab5923a5"
+        },
+        "a6e906c2-2586-4ed8-8b02-1e1b4ba40f38": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "d74dbdd1-5636-4bd3-9430-9e53397ae05c"
+        },
+        "c09fbaef-2401-493f-8b5f-e049bc484a68": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "831b482b-82af-40ba-8cc0-5e272f25cc2c"
+        },
+        "fe6b0a55-1954-464e-b607-74bef28df8c6": {
+            "gate": "5ff7ac8f-718d-436c-9d39-80f38d2b1363",
+            "pin": "f3a0ce45-6d5e-453b-9649-33baf57cc7b7"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "button",
+        "led",
+        "momentary",
+        "push",
+        "spst",
+        "switch"
+    ],
+    "type": "part",
+    "uuid": "aa548592-97ce-4747-b353-a6ce8e6ef49e",
+    "value": [
+        false,
+        "PB614"
+    ]
+}

--- a/parts/mechanical/switch/highly/PB6149L-bicolor-Base-Part.json
+++ b/parts/mechanical/switch/highly/PB6149L-bicolor-Base-Part.json
@@ -1,0 +1,64 @@
+{
+    "MPN": [
+        false,
+        "PB6149L-xx (bicolor LED, Base Part)"
+    ],
+    "datasheet": [
+        false,
+        "https://www.highly-elec.com/proimages/products/illuminated-tact-switch/PB614/PB614-2018.pdf"
+    ],
+    "description": [
+        false,
+        "Push Switch with bicolor LED"
+    ],
+    "entity": "21cee5dc-1474-4d88-8d49-7cf951837c32",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Highly Electric"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "8397e560-8cbd-4b14-b2a6-0bf40899b3dd",
+    "pad_map": {
+        "0c63d4d0-7aca-481a-a643-44811b571eea": {
+            "gate": "df610c11-99c6-4cd2-b025-64440002187d",
+            "pin": "92544877-7137-4395-8d80-8e04aad7f4ea"
+        },
+        "16dfdb65-dd3b-48e9-b035-5156b3616917": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "97955848-10f4-4667-b838-46f6bb8fe085"
+        },
+        "2bc9c38a-6bbf-45df-b04d-55fcb83a77e7": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "7f275da1-94c1-4a9b-8a2e-bfd4ab5923a5"
+        },
+        "a6e906c2-2586-4ed8-8b02-1e1b4ba40f38": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "d74dbdd1-5636-4bd3-9430-9e53397ae05c"
+        },
+        "c09fbaef-2401-493f-8b5f-e049bc484a68": {
+            "gate": "77d0364f-fb9a-4c49-8591-a7aacabc48a7",
+            "pin": "831b482b-82af-40ba-8cc0-5e272f25cc2c"
+        },
+        "fe6b0a55-1954-464e-b607-74bef28df8c6": {
+            "gate": "df610c11-99c6-4cd2-b025-64440002187d",
+            "pin": "56f8401d-41da-4166-985d-cea293dd9067"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "bicolor",
+        "led",
+        "momentary",
+        "push",
+        "spst",
+        "switch"
+    ],
+    "type": "part",
+    "uuid": "a892ef3d-234f-4be1-91e3-9f397aa98e9f",
+    "value": [
+        false,
+        "PB6149L"
+    ]
+}

--- a/symbols/opto/leds/led_bicolor_antiparallel.json
+++ b/symbols/opto/leds/led_bicolor_antiparallel.json
@@ -1,0 +1,771 @@
+{
+    "arcs": {},
+    "junctions": {
+        "004c6338-f817-4ad9-8c83-785cddf9c429": {
+            "position": [
+                -625000,
+                1250000
+            ]
+        },
+        "06ae85b6-7ba8-42bd-b7e7-1c6547b53994": {
+            "position": [
+                3750000,
+                2500000
+            ]
+        },
+        "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d": {
+            "position": [
+                -1875000,
+                0
+            ]
+        },
+        "1497a145-c698-4ef9-880b-e8fb2232e013": {
+            "position": [
+                -625000,
+                0
+            ]
+        },
+        "1fe07b87-5400-4198-8791-00cf2957c958": {
+            "position": [
+                -1250000,
+                2500000
+            ]
+        },
+        "2131d473-7d96-44f7-aebd-e1764275552c": {
+            "position": [
+                -1250000,
+                -1250000
+            ]
+        },
+        "3871dfc7-fc74-43a9-ab3a-27483d50ba20": {
+            "position": [
+                625000,
+                0
+            ]
+        },
+        "3b566588-7064-4a53-8608-31988b2d3fd1": {
+            "position": [
+                1250000,
+                -1250000
+            ]
+        },
+        "40e7fa19-720d-4dbd-a59e-2d485bbe383d": {
+            "position": [
+                625000,
+                -1250000
+            ]
+        },
+        "471b5a8f-f9e9-4832-b097-6ccc12eb9679": {
+            "position": [
+                -1250000,
+                -2500000
+            ]
+        },
+        "49c199a7-6a9e-4b57-8da4-d8d6d4f05b37": {
+            "position": [
+                3750000,
+                -2500000
+            ]
+        },
+        "57640d33-9d88-455e-966a-e738f5e5cff4": {
+            "position": [
+                1250000,
+                -2500000
+            ]
+        },
+        "614ffab6-6ac3-4811-a4ba-745460fd14df": {
+            "position": [
+                1250000,
+                -3750000
+            ]
+        },
+        "774abc80-f89b-4749-b2f8-3eb01289749e": {
+            "position": [
+                -1250000,
+                -3750000
+            ]
+        },
+        "79d00747-0305-4a8a-9d03-530170202b3a": {
+            "position": [
+                -3750000,
+                -2500000
+            ]
+        },
+        "7b4c0b90-8594-44a8-9dc2-2078bbc470d3": {
+            "position": [
+                625000,
+                -625000
+            ]
+        },
+        "7c628443-3d4d-4000-ae87-db4a0f17a14c": {
+            "position": [
+                1875000,
+                0
+            ]
+        },
+        "8c01c896-df97-4581-9601-3a3b8b5b4786": {
+            "position": [
+                1250000,
+                2500000
+            ]
+        },
+        "8e5a906b-e8e6-4407-b10d-02df71b594b0": {
+            "position": [
+                1250000,
+                0
+            ]
+        },
+        "93c7818d-ea58-4c3d-a673-8b29f94f6b9a": {
+            "position": [
+                -625000,
+                -1250000
+            ]
+        },
+        "9ea12d10-2806-4ebc-9da2-7be2bfa96c05": {
+            "position": [
+                1250000,
+                1250000
+            ]
+        },
+        "a8711db2-707b-44a3-b56f-1c772a605c02": {
+            "position": [
+                -1250000,
+                1250000
+            ]
+        },
+        "aae03c91-2c7e-49de-9eca-4581f860a09d": {
+            "position": [
+                -625000,
+                625000
+            ]
+        },
+        "b08d910f-a220-452f-b825-88f26b60c85c": {
+            "position": [
+                1875000,
+                -625000
+            ]
+        },
+        "b4171d72-3985-4b39-8a8b-812261c87e2d": {
+            "position": [
+                0,
+                1250000
+            ]
+        },
+        "cbd92b1c-0dbb-401d-92a2-43df146e399c": {
+            "position": [
+                1250000,
+                3750000
+            ]
+        },
+        "d1b7b6a7-a3fa-4823-b927-20262f7ec320": {
+            "position": [
+                -1250000,
+                0
+            ]
+        },
+        "d4d88a7d-cbf0-412c-b492-d91edb87585c": {
+            "position": [
+                -1250000,
+                3750000
+            ]
+        },
+        "d60ecd61-ebee-4f11-8fe2-e9d31925d135": {
+            "position": [
+                625000,
+                1250000
+            ]
+        },
+        "da4ecc0b-75c5-4619-9cb8-c411c0106465": {
+            "position": [
+                -1875000,
+                625000
+            ]
+        },
+        "e8761f7a-5716-4e8a-a6ad-c3432f4bd82f": {
+            "position": [
+                0,
+                0
+            ]
+        },
+        "ea908eb5-88ec-4c71-85c2-d3047d7bd347": {
+            "position": [
+                -1250000,
+                1250000
+            ]
+        },
+        "fee9fef0-38d1-48f9-ae91-7e1f95a646c2": {
+            "position": [
+                -3750000,
+                2500000
+            ]
+        }
+    },
+    "lines": {
+        "024e7f8a-90ff-45f0-b035-7ea066e8a99a": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "115d8a97-d828-4feb-8fcf-1c9c0688d8ea": {
+            "from": "79d00747-0305-4a8a-9d03-530170202b3a",
+            "layer": 0,
+            "to": "fee9fef0-38d1-48f9-ae91-7e1f95a646c2",
+            "width": 0
+        },
+        "1c88c7dd-3cf1-4a6e-8ed6-c8986218faa5": {
+            "from": "3871dfc7-fc74-43a9-ab3a-27483d50ba20",
+            "layer": 0,
+            "to": "7b4c0b90-8594-44a8-9dc2-2078bbc470d3",
+            "width": 0
+        },
+        "1d5ddb64-f0cc-4bc4-8928-7f8ef310e2a4": {
+            "from": "d60ecd61-ebee-4f11-8fe2-e9d31925d135",
+            "layer": 0,
+            "to": "1497a145-c698-4ef9-880b-e8fb2232e013",
+            "width": 0
+        },
+        "21a08b35-aebd-4e95-ae87-159712c8d2c5": {
+            "from": "774abc80-f89b-4749-b2f8-3eb01289749e",
+            "layer": 0,
+            "to": "57640d33-9d88-455e-966a-e738f5e5cff4",
+            "width": 0
+        },
+        "225653f8-6512-4be1-8dee-0db7371361dc": {
+            "from": "d4d88a7d-cbf0-412c-b492-d91edb87585c",
+            "layer": 0,
+            "to": "ea908eb5-88ec-4c71-85c2-d3047d7bd347",
+            "width": 0
+        },
+        "2af0cd65-b698-4bf9-aaca-37d7ee5a57b1": {
+            "from": "49c199a7-6a9e-4b57-8da4-d8d6d4f05b37",
+            "layer": 0,
+            "to": "57640d33-9d88-455e-966a-e738f5e5cff4",
+            "width": 0
+        },
+        "3c13a66b-89dd-417d-832d-e7f006c90f33": {
+            "from": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "layer": 0,
+            "to": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "width": 0
+        },
+        "4f4d5906-87cc-4323-a518-f188a99381e2": {
+            "from": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "layer": 0,
+            "to": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "width": 0
+        },
+        "55abe29f-d189-4129-89e6-e3f731893572": {
+            "from": "fee9fef0-38d1-48f9-ae91-7e1f95a646c2",
+            "layer": 0,
+            "to": "1fe07b87-5400-4198-8791-00cf2957c958",
+            "width": 0
+        },
+        "5a8af0f3-5934-4b83-b7e6-da6c689d6717": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "666a1a1d-f17b-41f1-ae9b-aeb5446f9c79": {
+            "from": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "layer": 0,
+            "to": "774abc80-f89b-4749-b2f8-3eb01289749e",
+            "width": 0
+        },
+        "6dcefb50-dba3-48bc-ab42-6146799dc5d2": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "cbd92b1c-0dbb-401d-92a2-43df146e399c",
+            "width": 0
+        },
+        "6e98c39f-e5a8-4b8f-9357-633b45ed1cba": {
+            "from": "004c6338-f817-4ad9-8c83-785cddf9c429",
+            "layer": 0,
+            "to": "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d",
+            "width": 0
+        },
+        "719b9459-8bf9-4bfb-b1ed-8431331f72d0": {
+            "from": "1497a145-c698-4ef9-880b-e8fb2232e013",
+            "layer": 0,
+            "to": "aae03c91-2c7e-49de-9eca-4581f860a09d",
+            "width": 0
+        },
+        "72974b1d-a2cd-436b-bc16-e13c67fc4a5a": {
+            "from": "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d",
+            "layer": 0,
+            "to": "d1b7b6a7-a3fa-4823-b927-20262f7ec320",
+            "width": 0
+        },
+        "77710cc7-5085-4a27-a262-f8a5ac64c145": {
+            "from": "7c628443-3d4d-4000-ae87-db4a0f17a14c",
+            "layer": 0,
+            "to": "8e5a906b-e8e6-4407-b10d-02df71b594b0",
+            "width": 0
+        },
+        "7962a575-5e2b-449f-8850-03fa44ebdf68": {
+            "from": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "layer": 0,
+            "to": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "width": 0
+        },
+        "800c63a8-2db2-417e-af4a-0b26fdd8be1d": {
+            "from": "614ffab6-6ac3-4811-a4ba-745460fd14df",
+            "layer": 0,
+            "to": "3b566588-7064-4a53-8608-31988b2d3fd1",
+            "width": 0
+        },
+        "8a97ef8a-b62b-4b30-8711-e98552bc9dc8": {
+            "from": "e8761f7a-5716-4e8a-a6ad-c3432f4bd82f",
+            "layer": 0,
+            "to": "1497a145-c698-4ef9-880b-e8fb2232e013",
+            "width": 0
+        },
+        "8c8c32ab-5a6d-46cd-b120-fce820dd2f2b": {
+            "from": "7c628443-3d4d-4000-ae87-db4a0f17a14c",
+            "layer": 0,
+            "to": "b08d910f-a220-452f-b825-88f26b60c85c",
+            "width": 0
+        },
+        "8f4f0912-4d5c-492e-a2b2-5e4f6b13ea18": {
+            "from": "471b5a8f-f9e9-4832-b097-6ccc12eb9679",
+            "layer": 0,
+            "to": "79d00747-0305-4a8a-9d03-530170202b3a",
+            "width": 0
+        },
+        "959a0f88-4797-4e27-b4d4-5dda1f8b649d": {
+            "from": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "af6e3ecd-2db0-4bee-8edd-a9900d6146bd": {
+            "from": "1fe07b87-5400-4198-8791-00cf2957c958",
+            "layer": 0,
+            "to": "9ea12d10-2806-4ebc-9da2-7be2bfa96c05",
+            "width": 0
+        },
+        "bcf2707b-51f4-4864-9fa0-6baa5acc2e56": {
+            "from": "3871dfc7-fc74-43a9-ab3a-27483d50ba20",
+            "layer": 0,
+            "to": "e8761f7a-5716-4e8a-a6ad-c3432f4bd82f",
+            "width": 0
+        },
+        "d838230d-8030-4ad0-8262-f4df76970d5d": {
+            "from": "cbd92b1c-0dbb-401d-92a2-43df146e399c",
+            "layer": 0,
+            "to": "1fe07b87-5400-4198-8791-00cf2957c958",
+            "width": 0
+        },
+        "d8572d2f-65bc-45c8-aece-15b5166b4a61": {
+            "from": "93c7818d-ea58-4c3d-a673-8b29f94f6b9a",
+            "layer": 0,
+            "to": "3871dfc7-fc74-43a9-ab3a-27483d50ba20",
+            "width": 0
+        },
+        "db316de6-5c28-4dc1-9b08-4e6685433b2a": {
+            "from": "8c01c896-df97-4581-9601-3a3b8b5b4786",
+            "layer": 0,
+            "to": "06ae85b6-7ba8-42bd-b7e7-1c6547b53994",
+            "width": 0
+        },
+        "e66da865-5f4a-451a-af31-9af6642242eb": {
+            "from": "40e7fa19-720d-4dbd-a59e-2d485bbe383d",
+            "layer": 0,
+            "to": "7c628443-3d4d-4000-ae87-db4a0f17a14c",
+            "width": 0
+        },
+        "f438297e-323e-4a37-91aa-96e26b71b556": {
+            "from": "57640d33-9d88-455e-966a-e738f5e5cff4",
+            "layer": 0,
+            "to": "2131d473-7d96-44f7-aebd-e1764275552c",
+            "width": 0
+        },
+        "fbfb2694-12c4-4f3e-9a1c-f9dcfe3496d3": {
+            "from": "0a0ba295-1e83-4190-b6cf-6c1eb6ca392d",
+            "layer": 0,
+            "to": "da4ecc0b-75c5-4619-9cb8-c411c0106465",
+            "width": 0
+        },
+        "fd03cde3-4b17-4668-8da4-17421882b261": {
+            "from": "06ae85b6-7ba8-42bd-b7e7-1c6547b53994",
+            "layer": 0,
+            "to": "49c199a7-6a9e-4b57-8da4-d8d6d4f05b37",
+            "width": 0
+        }
+    },
+    "name": "Two-terminal LED (bicolor, antiparallel)",
+    "pins": {
+        "56f8401d-41da-4166-985d-cea293dd9067": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": false,
+            "orientation": "left",
+            "pad_visible": false,
+            "position": [
+                -6250000,
+                0
+            ]
+        },
+        "92544877-7137-4395-8d80-8e04aad7f4ea": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": false,
+            "orientation": "right",
+            "pad_visible": false,
+            "position": [
+                6250000,
+                0
+            ]
+        }
+    },
+    "polygons": {
+        "0291ff29-ca7c-4150-bc71-ae05940f1e71": {
+            "layer": 0,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -3750000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3375000,
+                        0
+                    ],
+                    "type": "arc"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4125000,
+                        0
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "8a31f3d9-c35d-4750-aaeb-2afe0b654afb": {
+            "layer": 0,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        3750000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4125000,
+                        0
+                    ],
+                    "type": "arc"
+                },
+                {
+                    "arc_center": [
+                        7500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3375000,
+                        0
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "c6025862-9b08-40fc-ab10-26726a9a12d1": {
+            "layer": 0,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        3750000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3375000,
+                        0
+                    ],
+                    "type": "arc"
+                },
+                {
+                    "arc_center": [
+                        7500000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4125000,
+                        0
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "e37bde92-b8f7-4071-923d-782687a032c9": {
+            "layer": 0,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -3750000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3375000,
+                        0
+                    ],
+                    "type": "arc"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4125000,
+                        0
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "ec3f49bf-d1f7-4803-8472-d7a1dc0fbab1": {
+            "layer": 0,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        -3750000,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4125000,
+                        0
+                    ],
+                    "type": "arc"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3375000,
+                        0
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "text_placements": {
+        "0m": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 0,
+                "mirror": true,
+                "shift": [
+                    5000000,
+                    7500000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 0,
+                "mirror": true,
+                "shift": [
+                    5000000,
+                    5000000
+                ]
+            }
+        },
+        "0n": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    -5000000,
+                    7500000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    -5000000,
+                    5000000
+                ]
+            }
+        },
+        "180m": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5000000,
+                    -7500000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5000000,
+                    -5000000
+                ]
+            }
+        },
+        "180n": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 0,
+                "mirror": true,
+                "shift": [
+                    5000000,
+                    -7500000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 0,
+                "mirror": true,
+                "shift": [
+                    5000000,
+                    -5000000
+                ]
+            }
+        },
+        "270m": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -1250000,
+                    -5000000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    1250000,
+                    -5000000
+                ]
+            }
+        },
+        "270n": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 49152,
+                "mirror": true,
+                "shift": [
+                    -1250000,
+                    5000000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 49152,
+                "mirror": true,
+                "shift": [
+                    1250000,
+                    5000000
+                ]
+            }
+        },
+        "90m": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 49152,
+                "mirror": true,
+                "shift": [
+                    1250000,
+                    5000000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 49152,
+                "mirror": true,
+                "shift": [
+                    -1250000,
+                    5000000
+                ]
+            }
+        },
+        "90n": {
+            "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    1250000,
+                    -5000000
+                ]
+            },
+            "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+                "angle": 16384,
+                "mirror": true,
+                "shift": [
+                    -1250000,
+                    -5000000
+                ]
+            }
+        }
+    },
+    "texts": {
+        "59bcc9c5-c33f-47ff-9a2a-fab6f71b6099": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    -5000000,
+                    7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        },
+        "5c23635a-d0d4-4ed4-8533-5616f4471ed0": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    -5000000,
+                    5000000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "454c6b10-5bca-481e-a7e8-5da92961a3d9",
+    "uuid": "884f2d77-966c-41b6-b143-dddb08a315be"
+}

--- a/units/opto/leds/led_bicolor_antiparallel.json
+++ b/units/opto/leds/led_bicolor_antiparallel.json
@@ -1,0 +1,20 @@
+{
+    "manufacturer": "",
+    "name": "Two-terminal LED (bicolor, antiparallel)",
+    "pins": {
+        "56f8401d-41da-4166-985d-cea293dd9067": {
+            "direction": "passive",
+            "names": [],
+            "primary_name": "1",
+            "swap_group": 0
+        },
+        "92544877-7137-4395-8d80-8e04aad7f4ea": {
+            "direction": "passive",
+            "names": [],
+            "primary_name": "2",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "454c6b10-5bca-481e-a7e8-5da92961a3d9"
+}


### PR DESCRIPTION
This adds some of the Highly Electric [PB614 series](https://www.highly-elec.com/PB614-series.html) push switches.
I only added switches with actuator shape 9, without frame, standard type and without icons and such.

Switch manufacturers are always a little inprecise with their data sheets but I crosschecked with the switches I have on my desk.

Didn't create a 3D model tho, but maybe I will do that soon.