### PR TITLE
Add narrow variant to PJ301M-12 package

### DIFF
--- a/packages/connector/audio/PJ301M-12-narrow/package.json
+++ b/packages/connector/audio/PJ301M-12-narrow/package.json
@@ -1,0 +1,643 @@
+{
+    "alternate_for": "0a244d70-c6ed-4360-89c6-f55ee2b9435b",
+    "arcs": {
+        "1585ee57-a14e-45f5-a9d9-bb71dd8245d9": {
+            "center": "6b4740a1-0143-4899-b618-ec3b209ddd32",
+            "from": "f1c98c20-8032-4634-97d9-ddd4bbf7ea94",
+            "layer": 20,
+            "to": "0b3b3d5c-290d-445c-ae94-1179f625e895",
+            "width": 150000
+        },
+        "b1c9b792-0174-4bb3-8b4c-719f930405d4": {
+            "center": "6b4740a1-0143-4899-b618-ec3b209ddd32",
+            "from": "0b3b3d5c-290d-445c-ae94-1179f625e895",
+            "layer": 20,
+            "to": "f1c98c20-8032-4634-97d9-ddd4bbf7ea94",
+            "width": 150000
+        }
+    },
+    "default_model": "5089d975-6b43-4c2b-aea5-93806810e167",
+    "dimensions": {},
+    "junctions": {
+        "03167a4c-1fed-422e-b9e7-2102f66eff1d": {
+            "position": [
+                540000,
+                -4500000
+            ]
+        },
+        "084ae2eb-ea43-4550-85b5-52eb1b86ee04": {
+            "position": [
+                3240000,
+                -4500000
+            ]
+        },
+        "0b3b3d5c-290d-445c-ae94-1179f625e895": {
+            "position": [
+                -1800000,
+                0
+            ]
+        },
+        "0bc265b7-2898-46c9-a234-52c1cc95b688": {
+            "position": [
+                1410000,
+                6000000
+            ]
+        },
+        "0ce62880-940c-418f-b60a-dc6a6f5139ec": {
+            "position": [
+                4500000,
+                6084000
+            ]
+        },
+        "14af2dd6-af4b-4d8b-af72-6d9169008c1a": {
+            "position": [
+                -3240000,
+                -3600000
+            ]
+        },
+        "1619b388-6ca2-4a40-b197-1aec863644e9": {
+            "position": [
+                -1260000,
+                -3600000
+            ]
+        },
+        "169c3a24-be15-478b-8060-dcc313e97c2b": {
+            "position": [
+                -4500000,
+                -4500000
+            ]
+        },
+        "2ef38b36-325d-4f51-96fc-3a803571fac5": {
+            "position": [
+                -540000,
+                -4500000
+            ]
+        },
+        "61918333-119e-42d2-88ce-3eaaea8426a0": {
+            "position": [
+                1260000,
+                -3600000
+            ]
+        },
+        "6a8147a1-898d-4304-9386-a905931dcde9": {
+            "position": [
+                -540000,
+                -5220000
+            ]
+        },
+        "6b4740a1-0143-4899-b618-ec3b209ddd32": {
+            "position": [
+                0,
+                0
+            ]
+        },
+        "799021d6-f4d5-4c60-a3e6-863c6cf62878": {
+            "position": [
+                4500000,
+                -4500000
+            ]
+        },
+        "8b9b2412-4626-40d2-9fd0-ecebcde1bd5c": {
+            "position": [
+                540000,
+                -5220000
+            ]
+        },
+        "8f55a341-4131-41b0-aedc-9703d36a5007": {
+            "position": [
+                -4500000,
+                6084000
+            ]
+        },
+        "bc7d0621-4f58-4c01-8d56-0c7ae9feefbd": {
+            "position": [
+                1410000,
+                3600000
+            ]
+        },
+        "bdd773f5-5ed9-44db-ab7b-115f25b18e79": {
+            "position": [
+                -1410000,
+                3600000
+            ]
+        },
+        "ce9cbdef-acfb-470d-a214-eb3a41734903": {
+            "position": [
+                -1410000,
+                6000000
+            ]
+        },
+        "e8437a88-977f-4457-bcf0-0b40c2966d60": {
+            "position": [
+                3240000,
+                -3600000
+            ]
+        },
+        "ee49e4e4-4cd3-4fb4-a9ee-2a91b479fa94": {
+            "position": [
+                -3240000,
+                -4500000
+            ]
+        },
+        "f1c98c20-8032-4634-97d9-ddd4bbf7ea94": {
+            "position": [
+                1800000,
+                0
+            ]
+        }
+    },
+    "keepouts": {},
+    "lines": {
+        "0f891934-4762-4357-874d-fb6d40586ba7": {
+            "from": "0ce62880-940c-418f-b60a-dc6a6f5139ec",
+            "layer": 20,
+            "to": "799021d6-f4d5-4c60-a3e6-863c6cf62878",
+            "width": 150000
+        },
+        "217ce2f2-8839-4352-a0ad-034fb9a26d4d": {
+            "from": "6a8147a1-898d-4304-9386-a905931dcde9",
+            "layer": 20,
+            "to": "8b9b2412-4626-40d2-9fd0-ecebcde1bd5c",
+            "width": 150000
+        },
+        "2821ee11-8189-4912-a8f3-dcecdbe2b28f": {
+            "from": "ee49e4e4-4cd3-4fb4-a9ee-2a91b479fa94",
+            "layer": 20,
+            "to": "14af2dd6-af4b-4d8b-af72-6d9169008c1a",
+            "width": 150000
+        },
+        "2f7a059c-a3e4-47eb-969d-c9ce432f27a1": {
+            "from": "14af2dd6-af4b-4d8b-af72-6d9169008c1a",
+            "layer": 20,
+            "to": "1619b388-6ca2-4a40-b197-1aec863644e9",
+            "width": 150000
+        },
+        "477bebbc-db06-4ddb-b027-7d907febb7f5": {
+            "from": "169c3a24-be15-478b-8060-dcc313e97c2b",
+            "layer": 20,
+            "to": "8f55a341-4131-41b0-aedc-9703d36a5007",
+            "width": 150000
+        },
+        "4cfe3cf9-7c27-4019-9b79-9a6401661219": {
+            "from": "799021d6-f4d5-4c60-a3e6-863c6cf62878",
+            "layer": 20,
+            "to": "169c3a24-be15-478b-8060-dcc313e97c2b",
+            "width": 150000
+        },
+        "53e8d6a3-bb08-4954-94f7-ac241b2a8d66": {
+            "from": "8b9b2412-4626-40d2-9fd0-ecebcde1bd5c",
+            "layer": 20,
+            "to": "03167a4c-1fed-422e-b9e7-2102f66eff1d",
+            "width": 150000
+        },
+        "65b6e8d9-5527-4f61-a515-81ec0c714d95": {
+            "from": "ce9cbdef-acfb-470d-a214-eb3a41734903",
+            "layer": 20,
+            "to": "bdd773f5-5ed9-44db-ab7b-115f25b18e79",
+            "width": 150000
+        },
+        "8dc28478-2f78-4bec-9c1c-a290275cf9ac": {
+            "from": "bdd773f5-5ed9-44db-ab7b-115f25b18e79",
+            "layer": 20,
+            "to": "bc7d0621-4f58-4c01-8d56-0c7ae9feefbd",
+            "width": 150000
+        },
+        "a9fb0642-4446-49fa-a793-1eecb1ec17fd": {
+            "from": "2ef38b36-325d-4f51-96fc-3a803571fac5",
+            "layer": 20,
+            "to": "6a8147a1-898d-4304-9386-a905931dcde9",
+            "width": 150000
+        },
+        "c13216d9-fad9-43d7-85cc-2058fbb54fba": {
+            "from": "8f55a341-4131-41b0-aedc-9703d36a5007",
+            "layer": 20,
+            "to": "0ce62880-940c-418f-b60a-dc6a6f5139ec",
+            "width": 150000
+        },
+        "ea4d89f2-758a-4dae-a330-ac813717d03a": {
+            "from": "084ae2eb-ea43-4550-85b5-52eb1b86ee04",
+            "layer": 20,
+            "to": "e8437a88-977f-4457-bcf0-0b40c2966d60",
+            "width": 150000
+        },
+        "f4dccdbf-30e1-400e-98ae-028289311c34": {
+            "from": "e8437a88-977f-4457-bcf0-0b40c2966d60",
+            "layer": 20,
+            "to": "61918333-119e-42d2-88ce-3eaaea8426a0",
+            "width": 150000
+        },
+        "fb493fb1-328e-4faf-b5e9-190fbe95e944": {
+            "from": "bc7d0621-4f58-4c01-8d56-0c7ae9feefbd",
+            "layer": 20,
+            "to": "0bc265b7-2898-46c9-a234-52c1cc95b688",
+            "width": 150000
+        }
+    },
+    "manufacturer": "Wenzhou QingPu Electronics Co.",
+    "models": {
+        "5089d975-6b43-4c2b-aea5-93806810e167": {
+            "filename": "3d_models/connectors/audio/PJ301M-12.step",
+            "pitch": 0,
+            "roll": 0,
+            "x": 0,
+            "y": 0,
+            "yaw": 0,
+            "z": 0
+        }
+    },
+    "name": "PJ301M-12-narrow",
+    "pads": {
+        "353d4675-872d-4328-b528-121dfdf1102b": {
+            "name": "3",
+            "padstack": "4a0e654a-a96c-4c6b-939f-dd44887c78ab",
+            "parameter_set": {
+                "hole_diameter": 600000,
+                "hole_length": 1600000,
+                "pad_height": 1000000,
+                "pad_width": 2200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    4920000
+                ]
+            }
+        },
+        "5011dbab-2ede-48ef-b645-e374d5e85cba": {
+            "name": "M1",
+            "padstack": "762c84c2-187d-454a-af81-d3381bec5257",
+            "parameter_set": {
+                "hole_diameter": 3000000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "74027379-7de3-4266-aaad-3af9ad0668d2": {
+            "name": "2",
+            "padstack": "4a0e654a-a96c-4c6b-939f-dd44887c78ab",
+            "parameter_set": {
+                "hole_diameter": 600000,
+                "hole_length": 1600000,
+                "pad_height": 1000000,
+                "pad_width": 2200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -3380000
+                ]
+            }
+        },
+        "f4c5e76f-7d7f-42d8-b82f-a223d7277687": {
+            "name": "1",
+            "padstack": "4a0e654a-a96c-4c6b-939f-dd44887c78ab",
+            "parameter_set": {
+                "hole_diameter": 600000,
+                "hole_length": 1600000,
+                "pad_height": 1000000,
+                "pad_width": 2200000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    -5000000
+                ]
+            }
+        }
+    },
+    "parameter_program": "9.000mm 11.584mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.292mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "18c9569f-5eb2-427d-9535-847a6b26a9bf": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -375000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -375000,
+                        -4500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4500000,
+                        -4500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4500000,
+                        6084000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4500000,
+                        6084000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4500000,
+                        -4500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        375000,
+                        -4500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        375000,
+                        -5000000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "594b41b6-28e6-4254-9c41-5ab969c25724": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4500000,
+                        -4500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4500000,
+                        6084000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4500000,
+                        6084000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4500000,
+                        -4500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        375000,
+                        -4500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        375000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -375000,
+                        -5000000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -375000,
+                        -4500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "fd466e9f-ec94-4efc-aa65-e9cb6377f9ca": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4750000,
+                        -5750000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4750000,
+                        6334000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4750000,
+                        6334000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4750000,
+                        -5750000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "rules": {
+        "clearance_package": {
+            "clearance_silkscreen_cu": 200000,
+            "clearance_silkscreen_pkg": 200000,
+            "enabled": true,
+            "order": -1
+        },
+        "package_checks": {
+            "enabled": true,
+            "order": -1
+        }
+    },
+    "tags": [
+        "3.5mm",
+        "connector",
+        "jack",
+        "mono",
+        "phone",
+        "switched",
+        "vertical"
+    ],
+    "texts": {
+        "2badffa6-4067-4cc7-bb1d-f0a3dd8bc1b6": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    1200000,
+                    -5550000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "cc1c7419-cff4-486a-ab63-6c0c6a043bd1": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4500000,
+                    4500000
+                ]
+            },
+            "size": 1600000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "857c86e5-16ca-460c-b4aa-bff502ae0cc9"
+}


### PR DESCRIPTION
This is just an additional package variant for the PJ301M-12 which we already have in the pool (and which I used in many designs with some success). Pin 1 is closer to the body in that variant, which is totally feasible because the leg for pin 1 is roughly 11 mm long and flexible enough:  
![2021-03-12 09_39_21-Window](https://user-images.githubusercontent.com/6620266/110914700-036e9f80-8317-11eb-9d29-a9e144a5ceee.png)  

This can be helpful in some tight spaces (e.g. like the one I am having now : )
