### PR TITLE
Touch up QFN-16 package

### DIFF
--- a/packages/ic/qfn/qfn-16/package.json
+++ b/packages/ic/qfn/qfn-16/package.json
@@ -135,7 +135,7 @@
     },
     "name": "QFN-16 (3x3mm EP1.75x1.75mm)",
     "pads": {
-        "3129f981-a96c-4f00-8f9c-060fdfae9137": {
+        "521f5fa1-3693-4acf-b06b-b6a9b8a5cf30": {
             "name": "8",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -152,7 +152,7 @@
                 ]
             }
         },
-        "3cea5f05-f815-4b1a-a4c8-beaaf80d6a63": {
+        "01f1e369-1c09-4814-b1db-c74796494321": {
             "name": "3",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -169,7 +169,7 @@
                 ]
             }
         },
-        "3fb972d6-3cb9-4045-8400-9e43db232736": {
+        "ac26fbcb-be68-48ca-a9b5-3b411577d83a": {
             "name": "2",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -186,7 +186,7 @@
                 ]
             }
         },
-        "51e825fe-d574-444e-8024-24d0639ebb3a": {
+        "1d4d1b68-abe0-4666-ab40-84335a41c0ef": {
             "name": "10",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -203,7 +203,7 @@
                 ]
             }
         },
-        "72132391-fcbb-43c1-abaa-273386e0010f": {
+        "f70e0953-30c0-433b-b807-1b7e5458b58b": {
             "name": "11",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -220,7 +220,7 @@
                 ]
             }
         },
-        "7962b454-c956-42d8-a2b5-4b2bf6b2332e": {
+        "ec3aadbd-1165-4ac6-8d9d-64849d04e9cb": {
             "name": "5",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -237,7 +237,7 @@
                 ]
             }
         },
-        "869b6d45-d650-4bd5-a627-97b01d4128f9": {
+        "bbd532ef-1e8d-40aa-ad15-b064324d790c": {
             "name": "14",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -254,7 +254,7 @@
                 ]
             }
         },
-        "86cd22e9-4bfb-4637-90d4-8c0b6b09a084": {
+        "58f45942-ee32-47fd-9e4e-a16c1ae6cd8b": {
             "name": "15",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -271,7 +271,7 @@
                 ]
             }
         },
-        "8a504742-4ec1-4cdc-8a09-370b411cf6ae": {
+        "9e2ab086-173e-490f-b4e6-4814dea81b13": {
             "name": "12",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -288,7 +288,7 @@
                 ]
             }
         },
-        "903081ea-04b9-4a47-befd-a58e06b3a8ec": {
+        "1525a70a-9005-4b7f-9aba-ab9e9b70ae9b": {
             "name": "13",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -305,7 +305,7 @@
                 ]
             }
         },
-        "928b2848-0a40-434b-9e5d-e8dd3c5dc802": {
+        "770160ad-3e45-431c-8833-d1a3005649ba": {
             "name": "7",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -322,7 +322,7 @@
                 ]
             }
         },
-        "a3bf4225-5427-4ee6-9502-7250a38ea190": {
+        "67155d1b-c7e3-4893-b885-21572fe62676": {
             "name": "6",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -339,7 +339,7 @@
                 ]
             }
         },
-        "b71c8528-5428-4b02-ae48-8c9d41fc9828": {
+        "6233a030-3666-4de7-b3a8-4fda13d22ac3": {
             "name": "1",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -356,7 +356,7 @@
                 ]
             }
         },
-        "be96d52c-c165-4f82-8d80-4d4b0eaba6b1": {
+        "52b8e909-69c1-408f-a75e-59cab89a69d1": {
             "name": "9",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -373,7 +373,7 @@
                 ]
             }
         },
-        "c8ad3723-7dff-4576-a1fa-693adb8d371d": {
+        "0a48ff9a-4daf-41ab-90bf-a79ee6a9927a": {
             "name": "4",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
@@ -390,7 +390,7 @@
                 ]
             }
         },
-        "c990dd0b-3507-4a02-97b2-ffa4b73fa037": {
+        "a91890ed-7ab1-47b2-8fff-533d034fad8f": {
             "name": "16",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {

--- a/packages/ic/qfn/qfn-16/package.json
+++ b/packages/ic/qfn/qfn-16/package.json
@@ -135,23 +135,6 @@
     },
     "name": "QFN-16 (3x3mm EP1.75x1.75mm)",
     "pads": {
-        "521f5fa1-3693-4acf-b06b-b6a9b8a5cf30": {
-            "name": "8",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    750000,
-                    -1480000
-                ]
-            }
-        },
         "01f1e369-1c09-4814-b1db-c74796494321": {
             "name": "3",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
@@ -166,210 +149,6 @@
                 "shift": [
                     -1480000,
                     -250000
-                ]
-            }
-        },
-        "ac26fbcb-be68-48ca-a9b5-3b411577d83a": {
-            "name": "2",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 49152,
-                "mirror": false,
-                "shift": [
-                    -1480000,
-                    250000
-                ]
-            }
-        },
-        "1d4d1b68-abe0-4666-ab40-84335a41c0ef": {
-            "name": "10",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 16384,
-                "mirror": false,
-                "shift": [
-                    1480000,
-                    -250000
-                ]
-            }
-        },
-        "f70e0953-30c0-433b-b807-1b7e5458b58b": {
-            "name": "11",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 16384,
-                "mirror": false,
-                "shift": [
-                    1480000,
-                    250000
-                ]
-            }
-        },
-        "ec3aadbd-1165-4ac6-8d9d-64849d04e9cb": {
-            "name": "5",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    -750000,
-                    -1480000
-                ]
-            }
-        },
-        "bbd532ef-1e8d-40aa-ad15-b064324d790c": {
-            "name": "14",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 32768,
-                "mirror": false,
-                "shift": [
-                    250000,
-                    1480000
-                ]
-            }
-        },
-        "58f45942-ee32-47fd-9e4e-a16c1ae6cd8b": {
-            "name": "15",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 32768,
-                "mirror": false,
-                "shift": [
-                    -250000,
-                    1480000
-                ]
-            }
-        },
-        "9e2ab086-173e-490f-b4e6-4814dea81b13": {
-            "name": "12",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 16384,
-                "mirror": false,
-                "shift": [
-                    1480000,
-                    750000
-                ]
-            }
-        },
-        "1525a70a-9005-4b7f-9aba-ab9e9b70ae9b": {
-            "name": "13",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 32768,
-                "mirror": false,
-                "shift": [
-                    750000,
-                    1480000
-                ]
-            }
-        },
-        "770160ad-3e45-431c-8833-d1a3005649ba": {
-            "name": "7",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    250000,
-                    -1480000
-                ]
-            }
-        },
-        "67155d1b-c7e3-4893-b885-21572fe62676": {
-            "name": "6",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    -250000,
-                    -1480000
-                ]
-            }
-        },
-        "6233a030-3666-4de7-b3a8-4fda13d22ac3": {
-            "name": "1",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 49152,
-                "mirror": false,
-                "shift": [
-                    -1480000,
-                    750000
-                ]
-            }
-        },
-        "52b8e909-69c1-408f-a75e-59cab89a69d1": {
-            "name": "9",
-            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
-            "parameter_set": {
-                "corner_radius": 50000,
-                "pad_height": 750000,
-                "pad_width": 250000
-            },
-            "placement": {
-                "angle": 16384,
-                "mirror": false,
-                "shift": [
-                    1480000,
-                    -750000
                 ]
             }
         },
@@ -390,6 +169,159 @@
                 ]
             }
         },
+        "1525a70a-9005-4b7f-9aba-ab9e9b70ae9b": {
+            "name": "13",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 32768,
+                "mirror": false,
+                "shift": [
+                    750000,
+                    1480000
+                ]
+            }
+        },
+        "1d4d1b68-abe0-4666-ab40-84335a41c0ef": {
+            "name": "10",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    1480000,
+                    -250000
+                ]
+            }
+        },
+        "521f5fa1-3693-4acf-b06b-b6a9b8a5cf30": {
+            "name": "8",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    750000,
+                    -1480000
+                ]
+            }
+        },
+        "52b8e909-69c1-408f-a75e-59cab89a69d1": {
+            "name": "9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    1480000,
+                    -750000
+                ]
+            }
+        },
+        "58f45942-ee32-47fd-9e4e-a16c1ae6cd8b": {
+            "name": "15",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 32768,
+                "mirror": false,
+                "shift": [
+                    -250000,
+                    1480000
+                ]
+            }
+        },
+        "6233a030-3666-4de7-b3a8-4fda13d22ac3": {
+            "name": "1",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -1480000,
+                    750000
+                ]
+            }
+        },
+        "67155d1b-c7e3-4893-b885-21572fe62676": {
+            "name": "6",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -250000,
+                    -1480000
+                ]
+            }
+        },
+        "770160ad-3e45-431c-8833-d1a3005649ba": {
+            "name": "7",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    250000,
+                    -1480000
+                ]
+            }
+        },
+        "9e2ab086-173e-490f-b4e6-4814dea81b13": {
+            "name": "12",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    1480000,
+                    750000
+                ]
+            }
+        },
         "a91890ed-7ab1-47b2-8fff-533d034fad8f": {
             "name": "16",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
@@ -404,6 +336,74 @@
                 "shift": [
                     -750000,
                     1480000
+                ]
+            }
+        },
+        "ac26fbcb-be68-48ca-a9b5-3b411577d83a": {
+            "name": "2",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -1480000,
+                    250000
+                ]
+            }
+        },
+        "bbd532ef-1e8d-40aa-ad15-b064324d790c": {
+            "name": "14",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 32768,
+                "mirror": false,
+                "shift": [
+                    250000,
+                    1480000
+                ]
+            }
+        },
+        "ec3aadbd-1165-4ac6-8d9d-64849d04e9cb": {
+            "name": "5",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -750000,
+                    -1480000
+                ]
+            }
+        },
+        "f70e0953-30c0-433b-b807-1b7e5458b58b": {
+            "name": "11",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    1480000,
+                    250000
                 ]
             }
         },

--- a/packages/ic/qfn/qfn-16/package.json
+++ b/packages/ic/qfn/qfn-16/package.json
@@ -1,258 +1,123 @@
 {
-    "_imp": {
-        "grid_spacing": 1500000,
-        "layer_display": {
-            "layer_opacity": 50.0,
-            "layers": {
-                "-1": {
-                    "color": {
-                        "b": 0.0,
-                        "g": 1.0,
-                        "r": 1.0
-                    },
-                    "display_mode": "fill",
-                    "visible": false
-                },
-                "-100": {
-                    "color": {
-                        "b": 0.0,
-                        "g": 0.5,
-                        "r": 0.0
-                    },
-                    "display_mode": "fill_only",
-                    "visible": true
-                },
-                "-110": {
-                    "color": {
-                        "b": 0.25,
-                        "g": 0.5,
-                        "r": 0.25
-                    },
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "-120": {
-                    "color": {
-                        "b": 0.8999999761581421,
-                        "g": 0.8999999761581421,
-                        "r": 0.8999999761581421
-                    },
-                    "display_mode": "fill_only",
-                    "visible": false
-                },
-                "-130": {
-                    "color": {
-                        "b": 0.800000011920929,
-                        "g": 0.800000011920929,
-                        "r": 0.800000011920929
-                    },
-                    "display_mode": "fill",
-                    "visible": false
-                },
-                "-140": {
-                    "color": {
-                        "b": 0.5,
-                        "g": 0.5,
-                        "r": 0.5
-                    },
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "-150": {
-                    "color": {
-                        "b": 0.5,
-                        "g": 0.5,
-                        "r": 0.5
-                    },
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "-160": {
-                    "color": {
-                        "b": 0.5,
-                        "g": 0.5,
-                        "r": 0.5
-                    },
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "0": {
-                    "color": {
-                        "b": 0.0,
-                        "g": 0.0,
-                        "r": 1.0
-                    },
-                    "display_mode": "fill",
-                    "visible": true
-                },
-                "10": {
-                    "color": {
-                        "b": 0.5,
-                        "g": 0.5,
-                        "r": 1.0
-                    },
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "20": {
-                    "color": {
-                        "b": 0.8999999761581421,
-                        "g": 0.8999999761581421,
-                        "r": 0.8999999761581421
-                    },
-                    "display_mode": "fill_only",
-                    "visible": true
-                },
-                "30": {
-                    "color": {
-                        "b": 0.800000011920929,
-                        "g": 0.800000011920929,
-                        "r": 0.800000011920929
-                    },
-                    "display_mode": "fill",
-                    "visible": false
-                },
-                "40": {
-                    "color": {
-                        "b": 0.5,
-                        "g": 0.5,
-                        "r": 0.5
-                    },
-                    "display_mode": "outline",
-                    "visible": false
-                },
-                "50": {
-                    "color": {
-                        "b": 0.5,
-                        "g": 0.5,
-                        "r": 0.5
-                    },
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "60": {
-                    "color": {
-                        "b": 0.5,
-                        "g": 0.5,
-                        "r": 0.5
-                    },
-                    "display_mode": "outline",
-                    "visible": true
-                }
-            }
-        }
-    },
     "arcs": {},
     "default_model": "324c5a34-fd60-46c7-bc03-4c90d57cd3f8",
+    "dimensions": {},
     "junctions": {
-        "0c38c907-0f4b-4a5a-8077-998e45f974d4": {
+        "0fc96383-1d18-4d1b-a9ad-3d70d460ad5f": {
             "position": [
-                1700000,
-                -1700000
+                -1775000,
+                -1775000
             ]
         },
-        "0c7a0670-2150-4f19-93c7-1864e20c1e79": {
+        "1242eed1-d84d-4e0c-b854-207c6e86fff1": {
             "position": [
-                -1700000,
-                -1200000
+                -1150001,
+                -1775000
             ]
         },
-        "1455a634-b2f5-4da1-a0a8-7e70e05f64d4": {
+        "3d4b066f-47a0-4e32-bb01-43766c115099": {
             "position": [
-                1200000,
-                1700000
+                1775000,
+                1775000
             ]
         },
-        "1674ce53-d68e-4aa2-b457-88f13aa4a37c": {
+        "5230860b-c9ee-4dac-b9b7-6bdf022c53d3": {
             "position": [
-                1700000,
-                1200000
+                1775000,
+                -1150001
             ]
         },
-        "1f5a988a-a110-429e-aca0-dafda60e056b": {
+        "584f3151-c637-4475-9c68-d84338cdb493": {
             "position": [
-                1700000,
-                -1200000
+                1775000,
+                1150001
             ]
         },
-        "7079a32d-48b8-449a-bc1c-82202e3b4a91": {
+        "7188f6ff-ee6c-4725-b5af-e9d02f819c3a": {
             "position": [
-                -1200000,
-                1700000
+                -1775000,
+                1775000
             ]
         },
-        "7f2ac782-4e91-4ac1-a6fb-f1d2c7663611": {
+        "868ab8db-17b5-4190-bcdd-392182e1955a": {
             "position": [
-                -1700000,
-                -1700000
+                1150001,
+                1775000
             ]
         },
-        "95c19a69-94f6-44e0-8f2a-63b75511611c": {
+        "91440cf6-af26-49fe-a279-bd3487539fd0": {
             "position": [
-                -1200000,
-                -1700000
+                -1775000,
+                -1150001
             ]
         },
-        "98681b55-2699-44e5-9ac7-f8aaafbd799e": {
+        "a4cbf9ff-c2e1-4c66-a507-e2ea696f45d8": {
             "position": [
-                1200000,
-                -1700000
+                1150001,
+                -1775000
             ]
         },
-        "9fb40e81-d2bf-4e3b-9c46-7014378d422f": {
+        "a89eb738-5238-4dcf-9bac-b3e9193de5df": {
             "position": [
-                1700000,
-                1700000
+                1775000,
+                -1775000
             ]
         },
-        "cfb3bc51-008b-4fb2-999a-7a3187f33e62": {
+        "c3cee767-80f7-45b5-a24a-c45ae80df460": {
             "position": [
-                -1700000,
-                1700000
+                1775000,
+                1775000
+            ]
+        },
+        "f6d6b0f8-57db-41a6-a94c-5c05386cb788": {
+            "position": [
+                -1150001,
+                1775000
             ]
         }
     },
+    "keepouts": {},
     "lines": {
-        "01bacb51-3392-4886-8d59-1cff9087a138": {
-            "from": "1455a634-b2f5-4da1-a0a8-7e70e05f64d4",
+        "32fcef4c-8026-4e18-93e8-4ffc0dff4c9d": {
+            "from": "0fc96383-1d18-4d1b-a9ad-3d70d460ad5f",
             "layer": 20,
-            "to": "9fb40e81-d2bf-4e3b-9c46-7014378d422f",
+            "to": "1242eed1-d84d-4e0c-b854-207c6e86fff1",
             "width": 150000
         },
-        "210c1149-22d7-430b-8279-39bd1e32aa4f": {
-            "from": "95c19a69-94f6-44e0-8f2a-63b75511611c",
+        "3db528be-39de-4550-9270-3c07bec43ab9": {
+            "from": "584f3151-c637-4475-9c68-d84338cdb493",
             "layer": 20,
-            "to": "7f2ac782-4e91-4ac1-a6fb-f1d2c7663611",
+            "to": "c3cee767-80f7-45b5-a24a-c45ae80df460",
             "width": 150000
         },
-        "5617e482-4e63-45f3-b88c-2185c239e2ad": {
-            "from": "0c38c907-0f4b-4a5a-8077-998e45f974d4",
+        "50963acd-934e-4ade-b5d0-13121df0133d": {
+            "from": "91440cf6-af26-49fe-a279-bd3487539fd0",
             "layer": 20,
-            "to": "98681b55-2699-44e5-9ac7-f8aaafbd799e",
+            "to": "0fc96383-1d18-4d1b-a9ad-3d70d460ad5f",
             "width": 150000
         },
-        "5da955d0-6378-41e8-b4e5-d814a02f25f7": {
-            "from": "9fb40e81-d2bf-4e3b-9c46-7014378d422f",
+        "b42b0d83-af5b-4668-9767-0ae52a519a57": {
+            "from": "a4cbf9ff-c2e1-4c66-a507-e2ea696f45d8",
             "layer": 20,
-            "to": "1674ce53-d68e-4aa2-b457-88f13aa4a37c",
+            "to": "a89eb738-5238-4dcf-9bac-b3e9193de5df",
             "width": 150000
         },
-        "e24f1890-5073-4d48-a9ef-0d46f07b440a": {
-            "from": "7f2ac782-4e91-4ac1-a6fb-f1d2c7663611",
+        "ca03f115-d8da-41be-b674-09537204712e": {
+            "from": "a89eb738-5238-4dcf-9bac-b3e9193de5df",
             "layer": 20,
-            "to": "0c7a0670-2150-4f19-93c7-1864e20c1e79",
+            "to": "5230860b-c9ee-4dac-b9b7-6bdf022c53d3",
             "width": 150000
         },
-        "ea2ab95f-9e72-4cb9-99ea-1616c6e49447": {
-            "from": "1f5a988a-a110-429e-aca0-dafda60e056b",
+        "e2aadeeb-21b9-4f29-8e06-ea76cfc54733": {
+            "from": "3d4b066f-47a0-4e32-bb01-43766c115099",
             "layer": 20,
-            "to": "0c38c907-0f4b-4a5a-8077-998e45f974d4",
+            "to": "868ab8db-17b5-4190-bcdd-392182e1955a",
             "width": 150000
         },
-        "f1a0918f-fb3a-480f-8353-63f0979e92e8": {
-            "from": "cfb3bc51-008b-4fb2-999a-7a3187f33e62",
+        "e61d73c6-c772-4aa0-86d8-a59a17aff581": {
+            "from": "f6d6b0f8-57db-41a6-a94c-5c05386cb788",
             "layer": 20,
-            "to": "7079a32d-48b8-449a-bc1c-82202e3b4a91",
+            "to": "7188f6ff-ee6c-4725-b5af-e9d02f819c3a",
             "width": 150000
         }
     },
@@ -268,261 +133,277 @@
             "z": 0
         }
     },
-    "name": "QFN-16",
+    "name": "QFN-16 (3x3mm EP1.75x1.75mm)",
     "pads": {
-        "01f1e369-1c09-4814-b1db-c74796494321": {
-            "name": "3",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 49152,
-                "mirror": false,
-                "shift": [
-                    -1500000,
-                    -250000
-                ]
-            }
-        },
-        "0a48ff9a-4daf-41ab-90bf-a79ee6a9927a": {
-            "name": "4",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 49152,
-                "mirror": false,
-                "shift": [
-                    -1500000,
-                    -750000
-                ]
-            }
-        },
-        "1525a70a-9005-4b7f-9aba-ab9e9b70ae9b": {
-            "name": "13",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 32768,
-                "mirror": false,
-                "shift": [
-                    750000,
-                    1500000
-                ]
-            }
-        },
-        "1d4d1b68-abe0-4666-ab40-84335a41c0ef": {
-            "name": "10",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 16384,
-                "mirror": false,
-                "shift": [
-                    1500000,
-                    -250000
-                ]
-            }
-        },
-        "521f5fa1-3693-4acf-b06b-b6a9b8a5cf30": {
+        "3129f981-a96c-4f00-8f9c-060fdfae9137": {
             "name": "8",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
             },
             "placement": {
                 "angle": 0,
                 "mirror": false,
                 "shift": [
                     750000,
-                    -1500000
+                    -1480000
                 ]
             }
         },
-        "52b8e909-69c1-408f-a75e-59cab89a69d1": {
-            "name": "9",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
+        "3cea5f05-f815-4b1a-a4c8-beaaf80d6a63": {
+            "name": "3",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -1480000,
+                    -250000
+                ]
+            }
+        },
+        "3fb972d6-3cb9-4045-8400-9e43db232736": {
+            "name": "2",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -1480000,
+                    250000
+                ]
+            }
+        },
+        "51e825fe-d574-444e-8024-24d0639ebb3a": {
+            "name": "10",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    1500000,
+                    1480000,
+                    -250000
+                ]
+            }
+        },
+        "72132391-fcbb-43c1-abaa-273386e0010f": {
+            "name": "11",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    1480000,
+                    250000
+                ]
+            }
+        },
+        "7962b454-c956-42d8-a2b5-4b2bf6b2332e": {
+            "name": "5",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -750000,
+                    -1480000
+                ]
+            }
+        },
+        "869b6d45-d650-4bd5-a627-97b01d4128f9": {
+            "name": "14",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 32768,
+                "mirror": false,
+                "shift": [
+                    250000,
+                    1480000
+                ]
+            }
+        },
+        "86cd22e9-4bfb-4637-90d4-8c0b6b09a084": {
+            "name": "15",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 32768,
+                "mirror": false,
+                "shift": [
+                    -250000,
+                    1480000
+                ]
+            }
+        },
+        "8a504742-4ec1-4cdc-8a09-370b411cf6ae": {
+            "name": "12",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    1480000,
+                    750000
+                ]
+            }
+        },
+        "903081ea-04b9-4a47-befd-a58e06b3a8ec": {
+            "name": "13",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 32768,
+                "mirror": false,
+                "shift": [
+                    750000,
+                    1480000
+                ]
+            }
+        },
+        "928b2848-0a40-434b-9e5d-e8dd3c5dc802": {
+            "name": "7",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    250000,
+                    -1480000
+                ]
+            }
+        },
+        "a3bf4225-5427-4ee6-9502-7250a38ea190": {
+            "name": "6",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -250000,
+                    -1480000
+                ]
+            }
+        },
+        "b71c8528-5428-4b02-ae48-8c9d41fc9828": {
+            "name": "1",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 49152,
+                "mirror": false,
+                "shift": [
+                    -1480000,
+                    750000
+                ]
+            }
+        },
+        "be96d52c-c165-4f82-8d80-4d4b0eaba6b1": {
+            "name": "9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
+            "parameter_set": {
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    1480000,
                     -750000
                 ]
             }
         },
-        "58f45942-ee32-47fd-9e4e-a16c1ae6cd8b": {
-            "name": "15",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
+        "c8ad3723-7dff-4576-a1fa-693adb8d371d": {
+            "name": "4",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 32768,
-                "mirror": false,
-                "shift": [
-                    -250000,
-                    1500000
-                ]
-            }
-        },
-        "6233a030-3666-4de7-b3a8-4fda13d22ac3": {
-            "name": "1",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -1500000,
-                    750000
+                    -1480000,
+                    -750000
                 ]
             }
         },
-        "67155d1b-c7e3-4893-b885-21572fe62676": {
-            "name": "6",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    -250000,
-                    -1500000
-                ]
-            }
-        },
-        "770160ad-3e45-431c-8833-d1a3005649ba": {
-            "name": "7",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    250000,
-                    -1500000
-                ]
-            }
-        },
-        "9e2ab086-173e-490f-b4e6-4814dea81b13": {
-            "name": "12",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 16384,
-                "mirror": false,
-                "shift": [
-                    1500000,
-                    750000
-                ]
-            }
-        },
-        "a91890ed-7ab1-47b2-8fff-533d034fad8f": {
+        "c990dd0b-3507-4a02-97b2-ffa4b73fa037": {
             "name": "16",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
+                "corner_radius": 50000,
+                "pad_height": 750000,
+                "pad_width": 250000
             },
             "placement": {
                 "angle": 32768,
                 "mirror": false,
                 "shift": [
                     -750000,
-                    1500000
-                ]
-            }
-        },
-        "ac26fbcb-be68-48ca-a9b5-3b411577d83a": {
-            "name": "2",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 49152,
-                "mirror": false,
-                "shift": [
-                    -1500000,
-                    250000
-                ]
-            }
-        },
-        "bbd532ef-1e8d-40aa-ad15-b064324d790c": {
-            "name": "14",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 32768,
-                "mirror": false,
-                "shift": [
-                    250000,
-                    1500000
-                ]
-            }
-        },
-        "ec3aadbd-1165-4ac6-8d9d-64849d04e9cb": {
-            "name": "5",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    -750000,
-                    -1500000
-                ]
-            }
-        },
-        "f70e0953-30c0-433b-b807-1b7e5458b58b": {
-            "name": "11",
-            "padstack": "d2aad97e-e7b2-40f1-9ffe-2bc7e6df4c56",
-            "parameter_set": {
-                "pad_height": 800000,
-                "pad_width": 300000
-            },
-            "placement": {
-                "angle": 16384,
-                "mirror": false,
-                "shift": [
-                    1500000,
-                    250000
+                    1480000
                 ]
             }
         },
@@ -543,119 +424,11 @@
             }
         }
     },
-    "parameter_program": "3.800mm 3.800mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_program": "3.710mm 3.710mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
     "parameter_set": {
         "courtyard_expansion": 250000
     },
     "polygons": {
-        "4bec4efe-af11-4841-818c-e6d627e841b3": {
-            "layer": 40,
-            "parameter_class": "",
-            "vertices": [
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        -1500000,
-                        -1500000
-                    ],
-                    "type": "line"
-                },
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        -1500000,
-                        1500000
-                    ],
-                    "type": "line"
-                },
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        1500000,
-                        1500000
-                    ],
-                    "type": "line"
-                },
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        1500000,
-                        -1500000
-                    ],
-                    "type": "line"
-                }
-            ]
-        },
-        "574147bb-33aa-423b-89b4-617c6a8ddbd7": {
-            "layer": 60,
-            "parameter_class": "courtyard",
-            "vertices": [
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        -2150000,
-                        -2150000
-                    ],
-                    "type": "line"
-                },
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        -2150000,
-                        2150000
-                    ],
-                    "type": "line"
-                },
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        2150000,
-                        2150000
-                    ],
-                    "type": "line"
-                },
-                {
-                    "arc_center": [
-                        0,
-                        0
-                    ],
-                    "arc_reverse": false,
-                    "position": [
-                        2150000,
-                        -2150000
-                    ],
-                    "type": "line"
-                }
-            ]
-        },
         "696e8abe-6164-4055-8932-bc941b31f47f": {
             "layer": 50,
             "parameter_class": "",
@@ -721,6 +494,126 @@
                     "type": "line"
                 }
             ]
+        },
+        "8bcc249b-2370-4310-8b75-9e67abe46199": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        -1500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1500000,
+                        -1500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1500000,
+                        1500000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1500000,
+                        1500000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "f1843694-5287-44be-ac33-1a46dcfeae93": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2105000,
+                        -2105000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -2105000,
+                        2105000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2105000,
+                        2105000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        2105000,
+                        -2105000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "rules": {
+        "clearance_package": {
+            "clearance_silkscreen_cu": 200000,
+            "clearance_silkscreen_pkg": 200000,
+            "enabled": true,
+            "order": -1
+        },
+        "package_checks": {
+            "enabled": true,
+            "order": -1
         }
     },
     "tags": [
@@ -731,6 +624,7 @@
     ],
     "texts": {
         "1f17908c-0829-4bd5-b95d-88417a21f611": {
+            "font": "simplex",
             "from_smash": false,
             "layer": 50,
             "origin": "center",
@@ -747,6 +641,7 @@
             "width": 0
         },
         "fcd856b7-e5c1-453a-bdd2-b18246d81b8d": {
+            "font": "simplex",
             "from_smash": false,
             "layer": 20,
             "origin": "center",


### PR DESCRIPTION
The QFN-16 package in the library had some issues appear when I had a board manufactured using it.

Most importantly, the soldermask didn't correctly flow down the sides of the pads. Also the silkscreen was off.

I've regenerated this package using the IPC generator, which has the correct pin sizing, allowing soldermask to flow between the pins. I also regenerated the silkscreen to be 0.2mm from the part outline as guidelines recommend.