### PR TITLE
Update QFN-32 package and add hand-solderable version

### DIFF
--- a/packages/ic/qfn/qfn-32-handsolder/package.json
+++ b/packages/ic/qfn/qfn-32-handsolder/package.json
@@ -1,123 +1,124 @@
 {
+    "alternate_for": "f6b9cf93-f041-4fda-b977-a9ecf4fae984",
     "arcs": {},
     "default_model": "dad1bb6c-6266-4e11-9191-7d9932c34768",
     "dimensions": {},
     "junctions": {
-        "191ecf5e-1195-4eb5-b267-cba90df90919": {
-            "position": [
-                2775000,
-                -2151491
-            ]
-        },
-        "28d6fabd-ecc1-4d1b-b75d-858ac4ba7d99": {
-            "position": [
-                2775000,
-                2775000
-            ]
-        },
-        "40ea8f2f-6bf2-4e14-ac84-0c81ec95e541": {
-            "position": [
-                2775000,
-                2775000
-            ]
-        },
-        "59b1fb40-6e2e-49e8-855c-df86690b80fe": {
+        "19cb2966-c563-4a74-9827-f6e12d0f9e73": {
             "position": [
                 -2775000,
-                -2151491
+                -2165001
             ]
         },
-        "7ed83fa5-51e8-4f65-ac59-6cfe8b8c3e84": {
+        "1ad26e2f-6c79-44ea-96fc-96e319b064a9": {
             "position": [
-                -2151491,
-                -2775000
+                2165001,
+                2775000
             ]
         },
-        "819b14b4-1e6f-419e-977a-a8c16ebd5f66": {
+        "559f2d82-3dad-4d7a-bc6e-e5eca3f2105c": {
             "position": [
                 -2775000,
                 -2775000
             ]
         },
-        "95a0e8b6-996a-4c4f-9c61-3577750dc6f2": {
+        "624fe1db-4f9d-425d-bbd8-a64a63428be0": {
             "position": [
-                -2151491,
-                2775000
+                2775000,
+                -2165001
             ]
         },
-        "9973228d-7fa8-443d-bb57-97b8757175f0": {
+        "6c41fff8-3893-4755-b86f-29b129801a8c": {
             "position": [
-                2151491,
-                2775000
-            ]
-        },
-        "b9993328-d6c8-4dc9-88d3-c2dc11abd167": {
-            "position": [
-                2151491,
+                2165001,
                 -2775000
             ]
         },
-        "bdff8698-4916-48c9-b8ce-e97b38d79991": {
+        "6f014de4-3bd1-4805-bcf9-f24795035159": {
+            "position": [
+                2775000,
+                2775000
+            ]
+        },
+        "8687d79a-08b5-4c96-a8d0-8e196f5ac0b0": {
+            "position": [
+                -2165001,
+                2775000
+            ]
+        },
+        "8af2fa0a-afcb-4af9-b5b5-5c9f8f05d921": {
+            "position": [
+                2775000,
+                -2775000
+            ]
+        },
+        "abd53ce1-62f1-4fc9-b4ab-59cedbe82500": {
             "position": [
                 -2775000,
                 2775000
             ]
         },
-        "d2caa27f-517d-4255-b684-d13235573920": {
+        "c8076a8d-8bd0-4b2f-ab89-65e875017353": {
             "position": [
                 2775000,
-                -2775000
+                2775000
             ]
         },
-        "d5561dc6-bf82-4f88-a1d0-304f7ac6f903": {
+        "e0831b02-845f-40d5-acc1-25b6d84a1d39": {
             "position": [
                 2775000,
-                2151491
+                2165001
+            ]
+        },
+        "f2948aef-2c35-44be-a86a-3d5f1d19273a": {
+            "position": [
+                -2165001,
+                -2775000
             ]
         }
     },
     "keepouts": {},
     "lines": {
-        "2e5f753b-54de-40b9-aeb4-42c85c41e3d9": {
-            "from": "59b1fb40-6e2e-49e8-855c-df86690b80fe",
+        "0ebc711f-70fb-4585-a788-f317de957c71": {
+            "from": "8687d79a-08b5-4c96-a8d0-8e196f5ac0b0",
             "layer": 20,
-            "to": "819b14b4-1e6f-419e-977a-a8c16ebd5f66",
+            "to": "abd53ce1-62f1-4fc9-b4ab-59cedbe82500",
             "width": 150000
         },
-        "51cfaa4b-899e-4d1b-bb0f-bed4599cf1b1": {
-            "from": "819b14b4-1e6f-419e-977a-a8c16ebd5f66",
+        "12d3287f-49d7-4f8b-887e-b12107e0b943": {
+            "from": "8af2fa0a-afcb-4af9-b5b5-5c9f8f05d921",
             "layer": 20,
-            "to": "7ed83fa5-51e8-4f65-ac59-6cfe8b8c3e84",
+            "to": "624fe1db-4f9d-425d-bbd8-a64a63428be0",
             "width": 150000
         },
-        "8d0630b7-9213-43bf-954b-5e76894076f8": {
-            "from": "d5561dc6-bf82-4f88-a1d0-304f7ac6f903",
+        "30cf299a-4212-4dc7-91f0-caa76b8923e0": {
+            "from": "6c41fff8-3893-4755-b86f-29b129801a8c",
             "layer": 20,
-            "to": "28d6fabd-ecc1-4d1b-b75d-858ac4ba7d99",
+            "to": "8af2fa0a-afcb-4af9-b5b5-5c9f8f05d921",
             "width": 150000
         },
-        "8ff176f1-1419-4238-9103-8a68c4b076ba": {
-            "from": "95a0e8b6-996a-4c4f-9c61-3577750dc6f2",
+        "742ec1a2-6e6d-42bd-bab9-5f6da4374615": {
+            "from": "19cb2966-c563-4a74-9827-f6e12d0f9e73",
             "layer": 20,
-            "to": "bdff8698-4916-48c9-b8ce-e97b38d79991",
+            "to": "559f2d82-3dad-4d7a-bc6e-e5eca3f2105c",
             "width": 150000
         },
-        "e1379811-7b84-47e6-b2a0-2895a128f144": {
-            "from": "b9993328-d6c8-4dc9-88d3-c2dc11abd167",
+        "7ee673fb-e77f-4725-8368-d53f9c8f2683": {
+            "from": "e0831b02-845f-40d5-acc1-25b6d84a1d39",
             "layer": 20,
-            "to": "d2caa27f-517d-4255-b684-d13235573920",
+            "to": "c8076a8d-8bd0-4b2f-ab89-65e875017353",
             "width": 150000
         },
-        "e407d32b-0cbc-4a8d-9a6c-3c9aab50cecc": {
-            "from": "d2caa27f-517d-4255-b684-d13235573920",
+        "90c43afb-4ce5-46da-b3d5-64accd9abb2a": {
+            "from": "559f2d82-3dad-4d7a-bc6e-e5eca3f2105c",
             "layer": 20,
-            "to": "191ecf5e-1195-4eb5-b267-cba90df90919",
+            "to": "f2948aef-2c35-44be-a86a-3d5f1d19273a",
             "width": 150000
         },
-        "eb2c2f25-8feb-42bc-848b-21bc3bf4a39b": {
-            "from": "40ea8f2f-6bf2-4e14-ac84-0c81ec95e541",
+        "fa81b37c-c293-4233-9516-49cdddefd51a": {
+            "from": "6f014de4-3bd1-4805-bcf9-f24795035159",
             "layer": 20,
-            "to": "9973228d-7fa8-443d-bb57-97b8757175f0",
+            "to": "1ad26e2f-6c79-44ea-96fc-96e319b064a9",
             "width": 150000
         }
     },
@@ -133,14 +134,14 @@
             "z": 0
         }
     },
-    "name": "QFN-32 (5x5mm EP3.3x3.3mm)",
+    "name": "QFN-32 (5x5mm EP3.3x3.3mm Hand Solderable)",
     "pads": {
         "015aff1a-036b-44c4-b33c-8daa6594491c": {
             "name": "27",
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -148,7 +149,7 @@
                 "mirror": false,
                 "shift": [
                     750000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -157,7 +158,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -165,7 +166,7 @@
                 "mirror": false,
                 "shift": [
                     750000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
@@ -174,14 +175,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     250000
                 ]
             }
@@ -191,7 +192,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -199,7 +200,7 @@
                 "mirror": false,
                 "shift": [
                     -1750000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -208,14 +209,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     -750000
                 ]
             }
@@ -225,7 +226,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -233,7 +234,7 @@
                 "mirror": false,
                 "shift": [
                     1750000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -242,7 +243,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -250,7 +251,7 @@
                 "mirror": false,
                 "shift": [
                     -750000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
@@ -259,14 +260,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     -250000
                 ]
             }
@@ -276,14 +277,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     1250000
                 ]
             }
@@ -293,7 +294,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -301,7 +302,7 @@
                 "mirror": false,
                 "shift": [
                     250000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -310,14 +311,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     -750000
                 ]
             }
@@ -327,7 +328,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -335,7 +336,7 @@
                 "mirror": false,
                 "shift": [
                     -1250000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -344,7 +345,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -352,7 +353,7 @@
                 "mirror": false,
                 "shift": [
                     250000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
@@ -361,14 +362,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     -1750000
                 ]
             }
@@ -378,7 +379,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -386,7 +387,7 @@
                 "mirror": false,
                 "shift": [
                     -1250000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
@@ -395,14 +396,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     -1250000
                 ]
             }
@@ -412,7 +413,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -420,13 +421,13 @@
                 "mirror": false,
                 "shift": [
                     -250000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
         "9a0a889e-8792-411b-9c68-4253da8989a2": {
             "name": "PAD",
-            "padstack": "a3f7f6b2-3fa5-4c4b-b400-e6071a513877",
+            "padstack": "68b16848-450d-47cb-9a09-f98bebfe766b",
             "parameter_set": {
                 "pad_height": 3300000,
                 "pad_width": 3300000
@@ -445,14 +446,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     1750000
                 ]
             }
@@ -462,14 +463,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     1250000
                 ]
             }
@@ -479,14 +480,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     -1750000
                 ]
             }
@@ -496,14 +497,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     750000
                 ]
             }
@@ -513,14 +514,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     250000
                 ]
             }
@@ -530,14 +531,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     750000
                 ]
             }
@@ -547,14 +548,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2400000,
+                    2525000,
                     -250000
                 ]
             }
@@ -564,7 +565,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -572,7 +573,7 @@
                 "mirror": false,
                 "shift": [
                     -1750000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
@@ -581,7 +582,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -589,7 +590,7 @@
                 "mirror": false,
                 "shift": [
                     1750000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
@@ -598,7 +599,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -606,7 +607,7 @@
                 "mirror": false,
                 "shift": [
                     -250000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -615,7 +616,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -623,7 +624,7 @@
                 "mirror": false,
                 "shift": [
                     1250000,
-                    -2400000
+                    -2525000
                 ]
             }
         },
@@ -632,7 +633,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -640,7 +641,7 @@
                 "mirror": false,
                 "shift": [
                     -750000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -649,7 +650,7 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
@@ -657,7 +658,7 @@
                 "mirror": false,
                 "shift": [
                     1250000,
-                    2400000
+                    2525000
                 ]
             }
         },
@@ -666,14 +667,14 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     1750000
                 ]
             }
@@ -683,20 +684,20 @@
             "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
                 "corner_radius": 70000,
-                "pad_height": 700000,
+                "pad_height": 950000,
                 "pad_width": 280000
             },
             "placement": {
                 "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -2400000,
+                    -2525000,
                     -1250000
                 ]
             }
         }
     },
-    "parameter_program": "5.5mm dup\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0 0 ]",
+    "parameter_program": "6.000mm 6.000mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
     "parameter_set": {
         "courtyard_expansion": 250000
     },
@@ -712,8 +713,8 @@
                     ],
                     "arc_reverse": false,
                     "position": [
-                        -3000000,
-                        -3000000
+                        -3250000,
+                        -3250000
                     ],
                     "type": "line"
                 },
@@ -724,8 +725,8 @@
                     ],
                     "arc_reverse": false,
                     "position": [
-                        -3000000,
-                        3000000
+                        -3250000,
+                        3250000
                     ],
                     "type": "line"
                 },
@@ -736,8 +737,8 @@
                     ],
                     "arc_reverse": false,
                     "position": [
-                        3000000,
-                        3000000
+                        3250000,
+                        3250000
                     ],
                     "type": "line"
                 },
@@ -748,8 +749,8 @@
                     ],
                     "arc_reverse": false,
                     "position": [
-                        3000000,
-                        -3000000
+                        3250000,
+                        -3250000
                     ],
                     "type": "line"
                 }
@@ -931,5 +932,5 @@
         }
     },
     "type": "package",
-    "uuid": "f6b9cf93-f041-4fda-b977-a9ecf4fae984"
+    "uuid": "398d3f24-d1ca-4480-be7f-bce4dfb62178"
 }

--- a/packages/ic/qfn/qfn-32-handsolder/padstacks/pad.json
+++ b/packages/ic/qfn/qfn-32-handsolder/padstacks/pad.json
@@ -1,0 +1,118 @@
+{
+    "holes": {},
+    "name": "EP",
+    "padstack_type": "top",
+    "parameter_program": "3.3mm\nget-parameter [ solder_mask_expansion ] 2 * +\ndup\nset-shape [ mask rectangle ]",
+    "parameter_set": {
+        "solder_mask_expansion": 100000
+    },
+    "parameters_required": [],
+    "polygons": {},
+    "shapes": {
+        "2851ab55-b77f-4949-a63d-f6bcf8e4de21": {
+            "form": "rectangle",
+            "layer": 30,
+            "parameter_class": "",
+            "params": [
+                1237500,
+                1237500
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    825000,
+                    -825000
+                ]
+            }
+        },
+        "39e9c865-55bc-47e0-9152-562fb75d920a": {
+            "form": "rectangle",
+            "layer": 0,
+            "parameter_class": "",
+            "params": [
+                3300000,
+                3300000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        },
+        "83923de6-216c-4770-bd6b-cf4c31d66c08": {
+            "form": "rectangle",
+            "layer": 30,
+            "parameter_class": "",
+            "params": [
+                1237500,
+                1237500
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    825000,
+                    825000
+                ]
+            }
+        },
+        "85f02a4f-57b9-4d2a-8f07-84b04f81f949": {
+            "form": "rectangle",
+            "layer": 30,
+            "parameter_class": "",
+            "params": [
+                1237500,
+                1237500
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -825000,
+                    825000
+                ]
+            }
+        },
+        "95d28cb2-8b56-44e5-b986-be323c91498e": {
+            "form": "rectangle",
+            "layer": 30,
+            "parameter_class": "",
+            "params": [
+                1237500,
+                1237500
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -825000,
+                    -825000
+                ]
+            }
+        },
+        "c83834fd-e00a-4da9-b475-ed2f7c766cf6": {
+            "form": "rectangle",
+            "layer": 10,
+            "parameter_class": "",
+            "params": [
+                3300000,
+                3300000
+            ],
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    0,
+                    0
+                ]
+            }
+        }
+    },
+    "type": "padstack",
+    "uuid": "68b16848-450d-47cb-9a09-f98bebfe766b",
+    "well_known_name": ""
+}


### PR DESCRIPTION
This is basically the same as the old package, but with roundrects instead of half-obround, silkscreen to the new guidelines, and a name change to distinguish this version of qfn-32 from others with different pitches and exposed pads size. Also adds a hand-solderable version with more pad length exposed.

This rework was precipitated by creating another version for an MSP430 package which had a smaller exposed pad (2.1mm)