### PR TITLE
Fix SOT-363 assembly outline layer

### DIFF
--- a/packages/ic/smd/sot/sot-363/package.json
+++ b/packages/ic/smd/sot/sot-363/package.json
@@ -1,75 +1,23 @@
 {
-    "_imp": {
-        "grid_spacing": 100000,
-        "layer_display": {
-            "layer_opacity": 50.0,
-            "layers": {
-                "-1": {
-                    "display_mode": "fill",
-                    "visible": false
-                },
-                "-100": {
-                    "display_mode": "fill_only",
-                    "visible": true
-                },
-                "-110": {
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "-120": {
-                    "display_mode": "fill_only",
-                    "visible": false
-                },
-                "-130": {
-                    "display_mode": "fill",
-                    "visible": false
-                },
-                "-140": {
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "-150": {
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "-160": {
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "0": {
-                    "display_mode": "fill",
-                    "visible": true
-                },
-                "10": {
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "20": {
-                    "display_mode": "fill_only",
-                    "visible": true
-                },
-                "30": {
-                    "display_mode": "fill",
-                    "visible": false
-                },
-                "40": {
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "50": {
-                    "display_mode": "outline",
-                    "visible": true
-                },
-                "60": {
-                    "display_mode": "outline",
-                    "visible": true
-                }
-            }
-        }
-    },
     "arcs": {},
     "default_model": "b7a19b51-324c-4ce9-91f8-ca7b2ab55465",
     "dimensions": {},
+    "grid_settings": {
+        "current": {
+            "mode": "square",
+            "name": "",
+            "origin": [
+                0,
+                0
+            ],
+            "spacing_rect": [
+                1000000,
+                1000000
+            ],
+            "spacing_square": 100000
+        },
+        "grids": {}
+    },
     "junctions": {
         "8c0b9081-9ff9-44f3-8379-f5b42da895e5": {
             "position": [
@@ -127,8 +75,9 @@
     "pads": {
         "15f6028d-b6d0-46e4-b9b9-716367c20e52": {
             "name": "6",
-            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
+                "corner_radius": 100000,
                 "pad_height": 600000,
                 "pad_width": 420000
             },
@@ -143,8 +92,9 @@
         },
         "5afe2207-9077-4f3a-99be-9513e98634c1": {
             "name": "4",
-            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
+                "corner_radius": 100000,
                 "pad_height": 600000,
                 "pad_width": 420000
             },
@@ -159,8 +109,9 @@
         },
         "7314dc08-4ab0-4308-b8fe-ac9664caafd3": {
             "name": "5",
-            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
+                "corner_radius": 100000,
                 "pad_height": 600000,
                 "pad_width": 420000
             },
@@ -175,8 +126,9 @@
         },
         "a1db159f-a415-41e4-a920-6855ab964aac": {
             "name": "1",
-            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
+                "corner_radius": 100000,
                 "pad_height": 600000,
                 "pad_width": 420000
             },
@@ -191,8 +143,9 @@
         },
         "c28851fa-1824-44f1-849e-1c7571be475a": {
             "name": "3",
-            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
+                "corner_radius": 100000,
                 "pad_height": 600000,
                 "pad_width": 420000
             },
@@ -207,8 +160,9 @@
         },
         "ebfdb9dd-81b5-4d3d-9e9b-05c93f156cb3": {
             "name": "2",
-            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "padstack": "8e762581-e1b1-4fb4-81d3-7f8a1cabb97f",
             "parameter_set": {
+                "corner_radius": 100000,
                 "pad_height": 600000,
                 "pad_width": 420000
             },
@@ -228,7 +182,7 @@
     },
     "polygons": {
         "461e4269-14f8-4c4a-a7a4-da38c4ab6db6": {
-            "layer": 40,
+            "layer": 50,
             "parameter_class": "",
             "vertices": [
                 {
@@ -400,6 +354,18 @@
                     "type": "line"
                 }
             ]
+        }
+    },
+    "rules": {
+        "clearance_package": {
+            "clearance_silkscreen_cu": 200000,
+            "clearance_silkscreen_pkg": 200000,
+            "enabled": true,
+            "order": -1
+        },
+        "package_checks": {
+            "enabled": true,
+            "order": -1
         }
     },
     "tags": [


### PR DESCRIPTION
The assembly outline for SOT-363 was on the package layer, not the assembly layer.

I also converted the pads to roundrect while I was fixing this package.