### PR TITLE
Add STM32L15xCxTx

### DIFF
--- a/entities/ic/mcu/stm/STM32L15xCxTx.json
+++ b/entities/ic/mcu/stm/STM32L15xCxTx.json
@@ -1,0 +1,21 @@
+{
+    "gates": {
+        "ac6d19cf-b1bd-4c94-b526-095cbac224f4": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "3bcea7b6-840a-4856-96a2-1a52b446e50c"
+        }
+    },
+    "manufacturer": "ST",
+    "name": "STM32L15xCxTx",
+    "prefix": "U",
+    "tags": [
+        "arm",
+        "ic",
+        "mcu",
+        "stm32"
+    ],
+    "type": "entity",
+    "uuid": "c9dc9495-66d6-45b2-930c-e7db0a0e6c01"
+}

--- a/parts/ic/mcu/stm/STM32L151C8T6.json
+++ b/parts/ic/mcu/stm/STM32L151C8T6.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "STM32L151C8T6"
+    ],
+    "base": "da917d6c-3744-4768-954d-dcd7ce4e90e1",
+    "datasheet": [
+        true,
+        "https://www.st.com/resource/en/datasheet/stm32l151c8.pdf"
+    ],
+    "description": [
+        true,
+        "ARM Cortex-M3 32-bit MCU"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "ST"
+    ],
+    "model": "961be8fa-c15a-4816-be56-8c3a4caa54eb",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "9051fb0f-681a-4e38-8888-9ab4ad06e9a4",
+    "value": [
+        true,
+        "STM32L15xCxTx"
+    ]
+}

--- a/parts/ic/mcu/stm/STM32L15xCxTx.json
+++ b/parts/ic/mcu/stm/STM32L15xCxTx.json
@@ -19,9 +19,6 @@
         "ST"
     ],
     "model": "961be8fa-c15a-4816-be56-8c3a4caa54eb",
-    "orderable_MPNs": {
-        "6f4c79bc-446e-40b9-b709-aab710421bb0": "STM32L151C8T6"
-    },
     "package": "8f570fbd-9a66-491c-a9ad-c98d506c07fb",
     "pad_map": {
         "08cdb3cc-366f-44ab-a194-e81b53b5da46": {

--- a/parts/ic/mcu/stm/STM32L15xCxTx.json
+++ b/parts/ic/mcu/stm/STM32L15xCxTx.json
@@ -12,6 +12,11 @@
         "ARM Cortex-M3 32-bit MCU"
     ],
     "entity": "c9dc9495-66d6-45b2-930c-e7db0a0e6c01",
+    "flags": {
+        "base_part": "set",
+        "exclude_bom": "clear",
+        "exclude_pnp": "clear"
+    },
     "inherit_model": false,
     "inherit_tags": false,
     "manufacturer": [
@@ -226,5 +231,6 @@
     "value": [
         false,
         ""
-    ]
+    ],
+    "version": 1
 }

--- a/parts/ic/mcu/stm/STM32L15xCxTx.json
+++ b/parts/ic/mcu/stm/STM32L15xCxTx.json
@@ -1,0 +1,233 @@
+{
+    "MPN": [
+        false,
+        "STM32L15xCxTx"
+    ],
+    "datasheet": [
+        false,
+        "https://www.st.com/resource/en/datasheet/stm32l151c8.pdf"
+    ],
+    "description": [
+        false,
+        "ARM Cortex-M3 32-bit MCU"
+    ],
+    "entity": "c9dc9495-66d6-45b2-930c-e7db0a0e6c01",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "ST"
+    ],
+    "model": "961be8fa-c15a-4816-be56-8c3a4caa54eb",
+    "orderable_MPNs": {
+        "6f4c79bc-446e-40b9-b709-aab710421bb0": "STM32L151C8T6"
+    },
+    "package": "8f570fbd-9a66-491c-a9ad-c98d506c07fb",
+    "pad_map": {
+        "08cdb3cc-366f-44ab-a194-e81b53b5da46": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "aa7030ff-d17f-4381-b847-6df575efdf7d"
+        },
+        "09547d14-cfbd-4162-940b-d79eccb8c910": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "ea7ab7d2-c10b-4ec0-88ab-c40de46b1596"
+        },
+        "09890815-c0ef-4ef1-a32a-09d0fab3c427": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "26d5fed9-2a32-450f-8359-eb5482320776"
+        },
+        "0c918ae2-af36-45a7-9bd3-890c52a4754c": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "5a0ba0f4-2470-4031-9ceb-81b614ef4338"
+        },
+        "0f46d88f-a5ac-4a98-a3a2-f7b9d6bf5982": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "9a8ebe0e-53dc-4aba-98af-b7d40725a8df"
+        },
+        "0fac2929-66ea-4e29-93a4-b358959eac89": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "dfd29914-7d6f-4148-b7b8-30d3e4d53b24"
+        },
+        "212bcc25-aaf0-47d9-9ce7-da1e705b4168": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "ff7004c5-79d1-44b1-a755-9a4c90400ba5"
+        },
+        "23d62184-a24f-45d8-89c6-cef26cf05ad4": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "db6fee3f-2db4-4cae-a750-02acacb8e77d"
+        },
+        "316e0aa3-1560-4b46-aa35-a93f1580b051": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "58a99c57-18fb-418c-ad68-d98dd58ca88b"
+        },
+        "37e8f580-37ca-4aa3-997b-4032718b128a": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "3e633809-42d9-411f-a0c8-1c99e83e69ab"
+        },
+        "38c051e8-801f-41d7-9fab-49740f2f2bf1": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "5143bfaf-7475-47fc-b001-cf3490ebf997"
+        },
+        "41950001-d236-4f4b-aca8-7311167675e0": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "68f5076c-4b4d-4baf-abf7-f20cd0b3181f"
+        },
+        "47bbd386-5d07-4f38-b11d-a101b46195c4": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "0fe7061f-866f-4df8-85b4-dc8304320aaf"
+        },
+        "4dde5b6f-55a8-4a97-9f9e-dd0d71e401f5": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "5143bfaf-7475-47fc-b001-cf3490ebf997"
+        },
+        "534709e3-7987-43dc-870f-6c5f248221d8": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "ba1835bf-39ad-4b9c-8500-e0772832d636"
+        },
+        "574216f1-19ed-44fa-bb8c-b28f4d2c03d1": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "5b476dba-6b7b-4e55-a301-2f04d85ea46a"
+        },
+        "59f642c9-577b-48ac-953b-4491bbb74e2f": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "1def3927-06c7-47d2-b456-e39c56e2d229"
+        },
+        "5a813cb1-fc79-4cd8-ab66-1c872de99f15": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "71cd3b3a-72fa-490d-94a8-567441f28289"
+        },
+        "5e820a72-6e85-467e-a0c3-fa3936ea3136": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "4cc08703-d677-4859-b9a9-990b82cc9600"
+        },
+        "5f765184-03af-42bd-9431-c9df9a9f0e89": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "8a8dccb5-1bf9-497b-a5a1-752ddbccfa1c"
+        },
+        "6559f8f6-8f9a-49be-a148-4ed5a0522787": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "3b6c0a61-178b-4ba2-a6f7-284e461b6508"
+        },
+        "65ae5002-963a-49f4-a6d0-0b617a7e93c5": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "c0f1d637-8093-4a1c-9661-8b48ec0113b4"
+        },
+        "6632c867-8017-4b11-91e9-f9512cc41dd4": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "ef33d427-62ae-4421-bfbc-e5d7b2dfb608"
+        },
+        "6b6883c7-918f-4280-8421-3afcb09223c5": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "c760290b-a87b-46a3-bf98-b2ad7cc230eb"
+        },
+        "6d660fc1-a056-4194-bf50-f3f47c8b06ec": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "c41287fa-6305-448b-8827-a135e3379911"
+        },
+        "71c5bb3c-aae3-4ae8-a80c-2ba1e4c39b7e": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "2a8120b3-9d4f-4526-a8fd-fa9481c0cdd0"
+        },
+        "74c7b8ee-a0a2-4548-9899-6dde783281cf": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "ef2e7684-9bab-4c52-917d-08bff2f37938"
+        },
+        "75a52fc0-e95e-432f-a5f6-3ac32c93daff": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "007ad498-d102-4d1d-8618-ba48d992e4ff"
+        },
+        "7f395caa-1551-4463-a8a2-ab09d5d3739c": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "37db92bb-5e2d-441c-a1c9-c5f5b9240360"
+        },
+        "83267bd7-7991-4d62-8cc9-2bf873003f64": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "d40d3246-5128-4ad2-99ce-eaecda0a01d5"
+        },
+        "8ad2293a-6a6d-44fe-a796-4b232f399b4f": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "5649ce61-0926-43ac-b3af-44f4ee2d2caa"
+        },
+        "8f56d5dc-7c27-428b-8f13-7b429faaf0aa": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "8bcd2c35-b625-437a-8569-079078e4fc55"
+        },
+        "9c9152e8-636d-4751-a8b8-b8579642bb19": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "e58e0ee6-8821-46ec-900b-82d3b814ee96"
+        },
+        "9defcc2e-2651-41ca-a464-b029e0f206a4": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "c41287fa-6305-448b-8827-a135e3379911"
+        },
+        "b3275a0f-6395-42a8-a805-a598522c756d": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "5143bfaf-7475-47fc-b001-cf3490ebf997"
+        },
+        "b42ed341-45eb-403e-b90d-07f7e9fa6fe2": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "c2ed802d-ca9a-4f1e-82a8-f4840ca58745"
+        },
+        "b4730d4d-5e49-492e-a8bf-93a10cfd71f7": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "34054ed0-d505-4810-88b4-8ba880999334"
+        },
+        "bebcc044-6f13-4934-af71-a9d33595b901": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "c7231ab2-875a-4e42-b758-a446f03f0984"
+        },
+        "bf741351-fe24-4464-9373-89c37f848484": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "37a0a46d-91c9-46b7-8f1b-81344cccf131"
+        },
+        "c845834f-d484-4074-951f-2a82a86347ea": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "b26c9ad8-e5ac-45aa-8827-aa51caa1af7a"
+        },
+        "cf3d49fd-db49-45ef-b5e8-8b1563b5125e": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "d383cded-ccf0-4f23-a2fa-ebf1f794494f"
+        },
+        "dc1282cc-9ea6-4db8-b66b-2393835bb26d": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "4f9a1f17-4e53-4336-b1e4-8b40b7d364d1"
+        },
+        "e7aa4044-f4a1-467e-80b9-a79e93e1cbdd": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "b9b1789f-2b0a-482b-a2e9-855bad01d163"
+        },
+        "e9f84332-f685-4618-bf28-63f279d535d1": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "7803d9fc-337f-47a1-9616-4aedac93d3c6"
+        },
+        "eafca951-793e-4836-b6f9-f94247782029": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "4f48ea3f-0f61-44c9-b678-1c48c90e1f15"
+        },
+        "ebe9933f-34e1-42b8-9c8a-40afa835a168": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "7d59c169-7681-4194-8f32-dcca6e5652c1"
+        },
+        "f08a1a0b-fbd3-4c2f-9eb6-24b1800d2d9d": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "c41287fa-6305-448b-8827-a135e3379911"
+        },
+        "f88cec2c-2c68-4499-a7e0-d3324422e190": {
+            "gate": "ac6d19cf-b1bd-4c94-b526-095cbac224f4",
+            "pin": "4d6225fb-49fc-41e7-a8f0-a8aeaa04b0da"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "arm",
+        "ic",
+        "mcu",
+        "stm32"
+    ],
+    "type": "part",
+    "uuid": "da917d6c-3744-4768-954d-dcd7ce4e90e1",
+    "value": [
+        false,
+        ""
+    ]
+}

--- a/symbols/ic/mcu/stm/STM32L15xCxTx.json
+++ b/symbols/ic/mcu/stm/STM32L15xCxTx.json
@@ -1,6 +1,6 @@
 {
     "arcs": {},
-    "can_expand": false,
+    "can_expand": true,
     "junctions": {
         "03c1ea19-8524-4fdf-a120-aed09dd0126d": {
             "position": [
@@ -318,12 +318,12 @@
                 "schmitt": false
             },
             "length": 2500000,
-            "name_orientation": "in_line",
+            "name_orientation": "horizontal",
             "name_visible": true,
             "orientation": "down",
             "pad_visible": true,
             "position": [
-                2500000,
+                3750000,
                 -35000000
             ]
         },
@@ -607,12 +607,12 @@
                 "schmitt": false
             },
             "length": 2500000,
-            "name_orientation": "in_line",
+            "name_orientation": "horizontal",
             "name_visible": true,
             "orientation": "down",
             "pad_visible": true,
             "position": [
-                -2500000,
+                -3750000,
                 -35000000
             ]
         },

--- a/symbols/ic/mcu/stm/STM32L15xCxTx.json
+++ b/symbols/ic/mcu/stm/STM32L15xCxTx.json
@@ -1,0 +1,849 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "03c1ea19-8524-4fdf-a120-aed09dd0126d": {
+            "position": [
+                -22500000,
+                -32500000
+            ]
+        },
+        "489d67cb-df14-4d1a-af40-1d54fdc113a6": {
+            "position": [
+                -22500000,
+                32500000
+            ]
+        },
+        "4e5a57c3-f0fd-47db-93ea-0836a7162549": {
+            "position": [
+                22500000,
+                -32500000
+            ]
+        },
+        "6f21fc19-5cdc-4fdd-a513-8c2a43f86432": {
+            "position": [
+                22500000,
+                32500000
+            ]
+        }
+    },
+    "lines": {
+        "7bae9451-ad26-489b-92be-374db6f9f700": {
+            "from": "03c1ea19-8524-4fdf-a120-aed09dd0126d",
+            "layer": 0,
+            "to": "489d67cb-df14-4d1a-af40-1d54fdc113a6",
+            "width": 0
+        },
+        "836976c1-30d2-4082-a0ba-aa61bad729a2": {
+            "from": "489d67cb-df14-4d1a-af40-1d54fdc113a6",
+            "layer": 0,
+            "to": "6f21fc19-5cdc-4fdd-a513-8c2a43f86432",
+            "width": 0
+        },
+        "c3585d07-3a6f-4dc1-a623-f637bb39c3c1": {
+            "from": "6f21fc19-5cdc-4fdd-a513-8c2a43f86432",
+            "layer": 0,
+            "to": "4e5a57c3-f0fd-47db-93ea-0836a7162549",
+            "width": 0
+        },
+        "df281f5d-c6c9-422b-9272-a049114099ce": {
+            "from": "4e5a57c3-f0fd-47db-93ea-0836a7162549",
+            "layer": 0,
+            "to": "03c1ea19-8524-4fdf-a120-aed09dd0126d",
+            "width": 0
+        }
+    },
+    "name": "STM32L15xCxTx",
+    "pins": {
+        "007ad498-d102-4d1d-8618-ba48d992e4ff": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                5000000
+            ]
+        },
+        "0fe7061f-866f-4df8-85b4-dc8304320aaf": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                5000000
+            ]
+        },
+        "1def3927-06c7-47d2-b456-e39c56e2d229": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                15000000
+            ]
+        },
+        "26d5fed9-2a32-450f-8359-eb5482320776": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -15000000
+            ]
+        },
+        "2a8120b3-9d4f-4526-a8fd-fa9481c0cdd0": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -12500000
+            ]
+        },
+        "34054ed0-d505-4810-88b4-8ba880999334": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -7500000
+            ]
+        },
+        "37a0a46d-91c9-46b7-8f1b-81344cccf131": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                22500000
+            ]
+        },
+        "37db92bb-5e2d-441c-a1c9-c5f5b9240360": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                20000000
+            ]
+        },
+        "3b6c0a61-178b-4ba2-a6f7-284e461b6508": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -5000000
+            ]
+        },
+        "3e633809-42d9-411f-a0c8-1c99e83e69ab": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                12500000
+            ]
+        },
+        "4cc08703-d677-4859-b9a9-990b82cc9600": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -2500000
+            ]
+        },
+        "4d6225fb-49fc-41e7-a8f0-a8aeaa04b0da": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                17500000
+            ]
+        },
+        "4f48ea3f-0f61-44c9-b678-1c48c90e1f15": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -15000000
+            ]
+        },
+        "4f9a1f17-4e53-4336-b1e4-8b40b7d364d1": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -12500000
+            ]
+        },
+        "5143bfaf-7475-47fc-b001-cf3490ebf997": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                -3750000,
+                35000000
+            ]
+        },
+        "5649ce61-0926-43ac-b3af-44f4ee2d2caa": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                2500000,
+                -35000000
+            ]
+        },
+        "58a99c57-18fb-418c-ad68-d98dd58ca88b": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -20000000
+            ]
+        },
+        "5a0ba0f4-2470-4031-9ceb-81b614ef4338": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -5000000
+            ]
+        },
+        "5b476dba-6b7b-4e55-a301-2f04d85ea46a": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                0
+            ]
+        },
+        "68f5076c-4b4d-4baf-abf7-f20cd0b3181f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -20000000
+            ]
+        },
+        "71cd3b3a-72fa-490d-94a8-567441f28289": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                27500000
+            ]
+        },
+        "7803d9fc-337f-47a1-9616-4aedac93d3c6": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                2500000
+            ]
+        },
+        "7d59c169-7681-4194-8f32-dcca6e5652c1": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                3750000,
+                35000000
+            ]
+        },
+        "8a8dccb5-1bf9-497b-a5a1-752ddbccfa1c": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -2500000
+            ]
+        },
+        "8bcd2c35-b625-437a-8569-079078e4fc55": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                17500000
+            ]
+        },
+        "9a8ebe0e-53dc-4aba-98af-b7d40725a8df": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                12500000
+            ]
+        },
+        "aa7030ff-d17f-4381-b847-6df575efdf7d": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                0
+            ]
+        },
+        "b26c9ad8-e5ac-45aa-8827-aa51caa1af7a": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                2500000
+            ]
+        },
+        "b9b1789f-2b0a-482b-a2e9-855bad01d163": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -22500000
+            ]
+        },
+        "ba1835bf-39ad-4b9c-8500-e0772832d636": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                22500000
+            ]
+        },
+        "c0f1d637-8093-4a1c-9661-8b48ec0113b4": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -10000000
+            ]
+        },
+        "c2ed802d-ca9a-4f1e-82a8-f4840ca58745": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -7500000
+            ]
+        },
+        "c41287fa-6305-448b-8827-a135e3379911": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -2500000,
+                -35000000
+            ]
+        },
+        "c7231ab2-875a-4e42-b758-a446f03f0984": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                -10000000
+            ]
+        },
+        "c760290b-a87b-46a3-bf98-b2ad7cc230eb": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -22500000
+            ]
+        },
+        "d383cded-ccf0-4f23-a2fa-ebf1f794494f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                7500000
+            ]
+        },
+        "d40d3246-5128-4ad2-99ce-eaecda0a01d5": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                27500000
+            ]
+        },
+        "db6fee3f-2db4-4cae-a750-02acacb8e77d": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                15000000
+            ]
+        },
+        "dfd29914-7d6f-4148-b7b8-30d3e4d53b24": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                20000000
+            ]
+        },
+        "e58e0ee6-8821-46ec-900b-82d3b814ee96": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                25000000,
+                10000000
+            ]
+        },
+        "ea7ab7d2-c10b-4ec0-88ab-c40de46b1596": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                7500000
+            ]
+        },
+        "ef2e7684-9bab-4c52-917d-08bff2f37938": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                -25000000
+            ]
+        },
+        "ef33d427-62ae-4421-bfbc-e5d7b2dfb608": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -25000000,
+                10000000
+            ]
+        },
+        "ff7004c5-79d1-44b1-a755-9a4c90400ba5": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                35000000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {},
+    "texts": {
+        "3fe82020-5cda-433d-825f-8ac3993f8a2f": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    12500000,
+                    -33750000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        },
+        "62e37e68-d15b-454c-904e-81f28f8460d3": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    12500000,
+                    33750000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "3bcea7b6-840a-4856-96a2-1a52b446e50c",
+    "uuid": "597d9257-1aa8-4406-a60a-2c89baf5b728",
+    "version": 1
+}

--- a/units/ic/mcu/stm/STM32L15xCxTx.json
+++ b/units/ic/mcu/stm/STM32L15xCxTx.json
@@ -1,0 +1,480 @@
+{
+    "manufacturer": "ST",
+    "name": "STM32L15xCxTx",
+    "pins": {
+        "007ad498-d102-4d1d-8618-ba48d992e4ff": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN7",
+                "COMP1_INP",
+                "SPI1_MOSI",
+                "TIM11_CH1",
+                "TIM3_CH2",
+                "TIMX_IC4",
+                "TS_G2_IO2"
+            ],
+            "primary_name": "PA7",
+            "swap_group": 0
+        },
+        "0fe7061f-866f-4df8-85b4-dc8304320aaf": {
+            "direction": "bidirectional",
+            "names": [
+                "I2C1_SDA",
+                "SYS_PVD_IN",
+                "TIM4_CH2",
+                "USART1_RX"
+            ],
+            "primary_name": "PB7",
+            "swap_group": 0
+        },
+        "1def3927-06c7-47d2-b456-e39c56e2d229": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN3",
+                "COMP1_INP",
+                "TIM2_CH4",
+                "TIM9_CH2",
+                "TIMX_IC4",
+                "TS_G1_IO4",
+                "USART2_RX"
+            ],
+            "primary_name": "PA3",
+            "swap_group": 0
+        },
+        "26d5fed9-2a32-450f-8359-eb5482320776": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_EXTI15",
+                "SPI1_NSS",
+                "SYS_JTDI",
+                "TIM2_CH1",
+                "TIM2_ETR",
+                "TIMX_IC4",
+                "TS_G5_IO3"
+            ],
+            "primary_name": "PA15",
+            "swap_group": 0
+        },
+        "2a8120b3-9d4f-4526-a8fd-fa9481c0cdd0": {
+            "direction": "bidirectional",
+            "names": [
+                "SYS_JTCK-SWCLK",
+                "TIMX_IC3",
+                "TS_G5_IO2"
+            ],
+            "primary_name": "PA14",
+            "swap_group": 0
+        },
+        "34054ed0-d505-4810-88b4-8ba880999334": {
+            "direction": "bidirectional",
+            "names": [
+                "SPI1_MOSI",
+                "TIMX_IC1",
+                "USART1_RTS",
+                "USB_DP"
+            ],
+            "primary_name": "PA12",
+            "swap_group": 0
+        },
+        "37a0a46d-91c9-46b7-8f1b-81344cccf131": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN8",
+                "COMP1_INP",
+                "SYS_V_REF_OUT",
+                "TIM3_CH3",
+                "TS_G3_IO1"
+            ],
+            "primary_name": "PB0",
+            "swap_group": 0
+        },
+        "37db92bb-5e2d-441c-a1c9-c5f5b9240360": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN1",
+                "COMP1_INP",
+                "TIM2_CH2",
+                "TIMX_IC2",
+                "TS_G1_IO2",
+                "USART2_RTS"
+            ],
+            "primary_name": "PA1",
+            "swap_group": 0
+        },
+        "3b6c0a61-178b-4ba2-a6f7-284e461b6508": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_EXTI11",
+                "I2C2_SDA",
+                "TIM2_CH4",
+                "USART3_RX"
+            ],
+            "primary_name": "PB11",
+            "swap_group": 0
+        },
+        "3e633809-42d9-411f-a0c8-1c99e83e69ab": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN4",
+                "COMP1_INP",
+                "DAC_OUT1",
+                "SPI1_NSS",
+                "TIMX_IC1",
+                "USART2_CK"
+            ],
+            "primary_name": "PA4",
+            "swap_group": 0
+        },
+        "4cc08703-d677-4859-b9a9-990b82cc9600": {
+            "direction": "bidirectional",
+            "names": [
+                "TIMX_IC3",
+                "TS_G4_IO3",
+                "USART1_RX"
+            ],
+            "primary_name": "PA10",
+            "swap_group": 0
+        },
+        "4d6225fb-49fc-41e7-a8f0-a8aeaa04b0da": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN2",
+                "COMP1_INP",
+                "TIM2_CH3",
+                "TIM9_CH1",
+                "TIMX_IC3",
+                "TS_G1_IO3",
+                "USART2_TX"
+            ],
+            "primary_name": "PA2",
+            "swap_group": 0
+        },
+        "4f48ea3f-0f61-44c9-b678-1c48c90e1f15": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_EXTI15",
+                "ADC_IN21",
+                "COMP1_INP",
+                "RTC_REFIN",
+                "SPI2_MOSI",
+                "TIM11_CH1",
+                "TS_G7_IO4"
+            ],
+            "primary_name": "PB15",
+            "swap_group": 0
+        },
+        "4f9a1f17-4e53-4336-b1e4-8b40b7d364d1": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN20",
+                "COMP1_INP",
+                "SPI2_MISO",
+                "TIM9_CH2",
+                "TS_G7_IO3",
+                "USART3_RTS"
+            ],
+            "primary_name": "PB14",
+            "swap_group": 0
+        },
+        "5143bfaf-7475-47fc-b001-cf3490ebf997": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VDD",
+            "swap_group": 0
+        },
+        "5649ce61-0926-43ac-b3af-44f4ee2d2caa": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VSSA",
+            "swap_group": 0
+        },
+        "58a99c57-18fb-418c-ad68-d98dd58ca88b": {
+            "direction": "bidirectional",
+            "names": [
+                "RTC_OUT_ALARM",
+                "RTC_OUT_CALIB",
+                "RTC_TAMP1",
+                "RTC_TS",
+                "SYS_WKUP2",
+                "TIMX_IC2"
+            ],
+            "primary_name": "PC13-WKUP2",
+            "swap_group": 0
+        },
+        "5a0ba0f4-2470-4031-9ceb-81b614ef4338": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_EXTI11",
+                "SPI1_MISO",
+                "TIMX_IC4",
+                "USART1_CTS",
+                "USB_DM"
+            ],
+            "primary_name": "PA11",
+            "swap_group": 0
+        },
+        "5b476dba-6b7b-4e55-a301-2f04d85ea46a": {
+            "direction": "bidirectional",
+            "names": [
+                "DAC_EXTI9",
+                "TIMX_IC2",
+                "TS_G4_IO2",
+                "USART1_TX"
+            ],
+            "primary_name": "PA9",
+            "swap_group": 0
+        },
+        "68f5076c-4b4d-4baf-abf7-f20cd0b3181f": {
+            "direction": "bidirectional",
+            "names": [
+                "RCC_OSC_IN"
+            ],
+            "primary_name": "PH0-OSC_IN",
+            "swap_group": 0
+        },
+        "71cd3b3a-72fa-490d-94a8-567441f28289": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "NRST",
+            "swap_group": 0
+        },
+        "7803d9fc-337f-47a1-9616-4aedac93d3c6": {
+            "direction": "bidirectional",
+            "names": [
+                "RCC_MCO",
+                "TIMX_IC1",
+                "TS_G4_IO1",
+                "USART1_CK"
+            ],
+            "primary_name": "PA8",
+            "swap_group": 0
+        },
+        "7d59c169-7681-4194-8f32-dcca6e5652c1": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VLCD",
+            "swap_group": 0
+        },
+        "8a8dccb5-1bf9-497b-a5a1-752ddbccfa1c": {
+            "direction": "bidirectional",
+            "names": [
+                "I2C2_SCL",
+                "TIM2_CH3",
+                "USART3_TX"
+            ],
+            "primary_name": "PB10",
+            "swap_group": 0
+        },
+        "8bcd2c35-b625-437a-8569-079078e4fc55": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "PB2",
+            "swap_group": 0
+        },
+        "9a8ebe0e-53dc-4aba-98af-b7d40725a8df": {
+            "direction": "bidirectional",
+            "names": [
+                "COMP2_INP",
+                "SPI1_MISO",
+                "SYS_JTRST",
+                "TIM3_CH1",
+                "TS_G6_IO1"
+            ],
+            "primary_name": "PB4",
+            "swap_group": 0
+        },
+        "aa7030ff-d17f-4381-b847-6df575efdf7d": {
+            "direction": "bidirectional",
+            "names": [
+                "DAC_EXTI9",
+                "I2C1_SDA",
+                "TIM11_CH1",
+                "TIM4_CH4"
+            ],
+            "primary_name": "PB9",
+            "swap_group": 0
+        },
+        "b26c9ad8-e5ac-45aa-8827-aa51caa1af7a": {
+            "direction": "bidirectional",
+            "names": [
+                "I2C1_SCL",
+                "TIM10_CH1",
+                "TIM4_CH3"
+            ],
+            "primary_name": "PB8",
+            "swap_group": 0
+        },
+        "b9b1789f-2b0a-482b-a2e9-855bad01d163": {
+            "direction": "bidirectional",
+            "names": [
+                "RCC_OSC_OUT"
+            ],
+            "primary_name": "PH1-OSC_OUT",
+            "swap_group": 0
+        },
+        "ba1835bf-39ad-4b9c-8500-e0772832d636": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN0",
+                "COMP1_INP",
+                "SYS_WKUP1",
+                "TIM2_CH1",
+                "TIM2_ETR",
+                "TIMX_IC1",
+                "TS_G1_IO1",
+                "USART2_CTS"
+            ],
+            "primary_name": "PA0-WKUP1",
+            "swap_group": 0
+        },
+        "c0f1d637-8093-4a1c-9661-8b48ec0113b4": {
+            "direction": "bidirectional",
+            "names": [
+                "SYS_JTMS-SWDIO",
+                "TIMX_IC2",
+                "TS_G5_IO1"
+            ],
+            "primary_name": "PA13",
+            "swap_group": 0
+        },
+        "c2ed802d-ca9a-4f1e-82a8-f4840ca58745": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN18",
+                "COMP1_INP",
+                "I2C2_SMBA",
+                "SPI2_NSS",
+                "TIM10_CH1",
+                "TS_G7_IO1",
+                "USART3_CK"
+            ],
+            "primary_name": "PB12",
+            "swap_group": 0
+        },
+        "c41287fa-6305-448b-8827-a135e3379911": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VSS",
+            "swap_group": 0
+        },
+        "c7231ab2-875a-4e42-b758-a446f03f0984": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN19",
+                "COMP1_INP",
+                "SPI2_SCK",
+                "TIM9_CH1",
+                "TS_G7_IO2",
+                "USART3_CTS"
+            ],
+            "primary_name": "PB13",
+            "swap_group": 0
+        },
+        "c760290b-a87b-46a3-bf98-b2ad7cc230eb": {
+            "direction": "bidirectional",
+            "names": [
+                "RCC_OSC32_IN",
+                "TIMX_IC3"
+            ],
+            "primary_name": "PC14-OSC32_IN",
+            "swap_group": 0
+        },
+        "d383cded-ccf0-4f23-a2fa-ebf1f794494f": {
+            "direction": "bidirectional",
+            "names": [
+                "I2C1_SCL",
+                "TIM4_CH1",
+                "USART1_TX"
+            ],
+            "primary_name": "PB6",
+            "swap_group": 0
+        },
+        "d40d3246-5128-4ad2-99ce-eaecda0a01d5": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "BOOT0",
+            "swap_group": 0
+        },
+        "db6fee3f-2db4-4cae-a750-02acacb8e77d": {
+            "direction": "bidirectional",
+            "names": [
+                "COMP2_INM",
+                "SPI1_SCK",
+                "SYS_JTDO-TRACESWO",
+                "TIM2_CH2"
+            ],
+            "primary_name": "PB3",
+            "swap_group": 0
+        },
+        "dfd29914-7d6f-4148-b7b8-30d3e4d53b24": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN9",
+                "COMP1_INP",
+                "SYS_V_REF_OUT",
+                "TIM3_CH4",
+                "TS_G3_IO2"
+            ],
+            "primary_name": "PB1",
+            "swap_group": 0
+        },
+        "e58e0ee6-8821-46ec-900b-82d3b814ee96": {
+            "direction": "bidirectional",
+            "names": [
+                "COMP2_INP",
+                "I2C1_SMBA",
+                "SPI1_MOSI",
+                "TIM3_CH2",
+                "TS_G6_IO2"
+            ],
+            "primary_name": "PB5",
+            "swap_group": 0
+        },
+        "ea7ab7d2-c10b-4ec0-88ab-c40de46b1596": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN6",
+                "COMP1_INP",
+                "SPI1_MISO",
+                "TIM10_CH1",
+                "TIM3_CH1",
+                "TIMX_IC3",
+                "TS_G2_IO1"
+            ],
+            "primary_name": "PA6",
+            "swap_group": 0
+        },
+        "ef2e7684-9bab-4c52-917d-08bff2f37938": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_EXTI15",
+                "RCC_OSC32_OUT",
+                "TIMX_IC4"
+            ],
+            "primary_name": "PC15-OSC32_OUT",
+            "swap_group": 0
+        },
+        "ef33d427-62ae-4421-bfbc-e5d7b2dfb608": {
+            "direction": "bidirectional",
+            "names": [
+                "ADC_IN5",
+                "COMP1_INP",
+                "DAC_OUT2",
+                "SPI1_SCK",
+                "TIM2_CH1",
+                "TIM2_ETR",
+                "TIMX_IC2"
+            ],
+            "primary_name": "PA5",
+            "swap_group": 0
+        },
+        "ff7004c5-79d1-44b1-a755-9a4c90400ba5": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VDDA",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "3bcea7b6-840a-4856-96a2-1a52b446e50c"
+}


### PR DESCRIPTION
I'm not sure if putting an 'x' in the number is a good idea but the [datasheet](https://www.st.com/resource/en/datasheet/stm32l151c8.pdf) is shared between STM32L151x6/8/B and STM32L152x6/8/B, the pinout figure is titled "STM32L15xCx LQFP48 pinout".

Also I guess other STM32s all have short pin names but it does seem like e.g. "WKUP2" is part of the whole "PC13-WKUP2" name, it was imported like that from the CubeMX xml file and this is how it is in the pinout in the datasheet as well… hmm.