### PR TITLE
Add USB connector TYPE-C-31-M-12 from Korean Hroparts

### DIFF
--- a/packages/connector/usb/krhro/type-c-31-m-12/package.json
+++ b/packages/connector/usb/krhro/type-c-31-m-12/package.json
@@ -1,0 +1,626 @@
+{
+    "arcs": {},
+    "default_model": "00000000-0000-0000-0000-000000000000",
+    "dimensions": {},
+    "grid_settings": {
+        "current": {
+            "mode": "square",
+            "name": "",
+            "origin": [
+                0,
+                0
+            ],
+            "spacing_rect": [
+                1000000,
+                1000000
+            ],
+            "spacing_square": 100000
+        },
+        "grids": {}
+    },
+    "junctions": {
+        "0d37d21e-5f8c-45a8-b8ed-991500fe086c": {
+            "position": [
+                -3900000,
+                4800000
+            ]
+        },
+        "19252aca-d355-4d17-8dc8-9b7f9d734b4c": {
+            "position": [
+                -4900000,
+                4300000
+            ]
+        },
+        "22ecc6df-fbda-42a3-b5d2-3b5fc0ab87b9": {
+            "position": [
+                -4900000,
+                4800000
+            ]
+        },
+        "303c2741-f0c9-483b-9cc6-1334423ad1f5": {
+            "position": [
+                -4800000,
+                0
+            ]
+        },
+        "35788b56-9a6a-4d11-882e-aab5d992df1b": {
+            "position": [
+                3900000,
+                4800000
+            ]
+        },
+        "3a62caa6-f2ed-4923-9fcf-d1efab9f5d24": {
+            "position": [
+                4800000,
+                -3600000
+            ]
+        },
+        "3f653e1c-12a6-4373-9450-b1357b380959": {
+            "position": [
+                4800000,
+                0
+            ]
+        },
+        "558269e1-6a2c-464c-98e3-ad7afab46fb4": {
+            "position": [
+                -4800000,
+                -2100000
+            ]
+        },
+        "8e8f01e1-d7d9-4178-95a2-7755a7afdf68": {
+            "position": [
+                4900000,
+                4300000
+            ]
+        },
+        "96ac76fc-85e2-40b5-ae12-beb594f3e8ff": {
+            "position": [
+                4800000,
+                -2100000
+            ]
+        },
+        "9c34d8ca-478c-46c1-af9e-f7cfa5b84593": {
+            "position": [
+                4900000,
+                4800000
+            ]
+        },
+        "aee80e96-0865-4b61-8261-5d7d8787f378": {
+            "position": [
+                4800000,
+                1800000
+            ]
+        },
+        "c6b625da-e275-44dc-b8c1-09d69bbdfca7": {
+            "position": [
+                -4800000,
+                -3600000
+            ]
+        },
+        "cfa78cfe-c70f-4b3c-9d62-180503b762a1": {
+            "position": [
+                -4800000,
+                1800000
+            ]
+        }
+    },
+    "keepouts": {},
+    "lines": {
+        "2edc6b19-4081-48db-83df-ec8f7f37548b": {
+            "from": "cfa78cfe-c70f-4b3c-9d62-180503b762a1",
+            "layer": 20,
+            "to": "303c2741-f0c9-483b-9cc6-1334423ad1f5",
+            "width": 150000
+        },
+        "440133ab-e28f-4ebe-b645-b9c53a829680": {
+            "from": "9c34d8ca-478c-46c1-af9e-f7cfa5b84593",
+            "layer": 20,
+            "to": "8e8f01e1-d7d9-4178-95a2-7755a7afdf68",
+            "width": 150000
+        },
+        "70bb1667-712d-4378-b7b3-881c602df9b3": {
+            "from": "22ecc6df-fbda-42a3-b5d2-3b5fc0ab87b9",
+            "layer": 20,
+            "to": "19252aca-d355-4d17-8dc8-9b7f9d734b4c",
+            "width": 150000
+        },
+        "826c3b04-aec9-489f-b2fe-1f1dfb5e2726": {
+            "from": "0d37d21e-5f8c-45a8-b8ed-991500fe086c",
+            "layer": 20,
+            "to": "22ecc6df-fbda-42a3-b5d2-3b5fc0ab87b9",
+            "width": 150000
+        },
+        "b5b5c4ff-fae7-4c93-be83-d9c239fc36db": {
+            "from": "35788b56-9a6a-4d11-882e-aab5d992df1b",
+            "layer": 20,
+            "to": "9c34d8ca-478c-46c1-af9e-f7cfa5b84593",
+            "width": 150000
+        },
+        "ca4436b1-4028-423b-9edb-91f8fe53140a": {
+            "from": "96ac76fc-85e2-40b5-ae12-beb594f3e8ff",
+            "layer": 20,
+            "to": "3a62caa6-f2ed-4923-9fcf-d1efab9f5d24",
+            "width": 150000
+        },
+        "ec71967d-5cc6-42c4-808a-c7d32d7af38c": {
+            "from": "558269e1-6a2c-464c-98e3-ad7afab46fb4",
+            "layer": 20,
+            "to": "c6b625da-e275-44dc-b8c1-09d69bbdfca7",
+            "width": 150000
+        },
+        "f12c20bf-3cee-423c-9e06-152fe064ea10": {
+            "from": "aee80e96-0865-4b61-8261-5d7d8787f378",
+            "layer": 20,
+            "to": "3f653e1c-12a6-4373-9450-b1357b380959",
+            "width": 150000
+        }
+    },
+    "manufacturer": "Korean Hroparts",
+    "models": {},
+    "name": "TYPE-C-31-M-12",
+    "pads": {
+        "0eb110b0-8492-4998-92a9-5f54d197e77f": {
+            "name": "S4",
+            "padstack": "4a0e654a-a96c-4c6b-939f-dd44887c78ab",
+            "parameter_set": {
+                "hole_diameter": 600000,
+                "hole_length": 1400000,
+                "pad_height": 1000000,
+                "pad_width": 1600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    4320000,
+                    -1050000
+                ]
+            }
+        },
+        "292a75f6-ca58-4c7c-a5ef-1b0835307998": {
+            "name": "B7",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -750000,
+                    4045000
+                ]
+            }
+        },
+        "35069a15-d76f-4067-8da9-c2e5830f2594": {
+            "name": "B6",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    750000,
+                    4045000
+                ]
+            }
+        },
+        "37799a60-1ba1-43fe-a9de-8fcf009dfd8d": {
+            "name": "A7",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    250000,
+                    4045000
+                ]
+            }
+        },
+        "42d494d9-8c52-4442-acf2-21dcd7712353": {
+            "name": "S2",
+            "padstack": "4a0e654a-a96c-4c6b-939f-dd44887c78ab",
+            "parameter_set": {
+                "hole_diameter": 600000,
+                "hole_length": 1700000,
+                "pad_height": 1000000,
+                "pad_width": 2100000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    4320000,
+                    3130000
+                ]
+            }
+        },
+        "53f29b72-b570-4a86-ba4f-d351aa74f4f5": {
+            "name": "S1",
+            "padstack": "4a0e654a-a96c-4c6b-939f-dd44887c78ab",
+            "parameter_set": {
+                "hole_diameter": 600000,
+                "hole_length": 1700000,
+                "pad_height": 1000000,
+                "pad_width": 2100000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    -4320000,
+                    3130000
+                ]
+            }
+        },
+        "685f9220-20a0-4286-9536-d0c97e871b2d": {
+            "name": "A4B9",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2450000,
+                    4045000
+                ]
+            }
+        },
+        "6b646a4a-36f6-480c-b997-f62fa89e640e": {
+            "name": "S3",
+            "padstack": "4a0e654a-a96c-4c6b-939f-dd44887c78ab",
+            "parameter_set": {
+                "hole_diameter": 600000,
+                "hole_length": 1400000,
+                "pad_height": 1000000,
+                "pad_width": 1600000
+            },
+            "placement": {
+                "angle": 16384,
+                "mirror": false,
+                "shift": [
+                    -4320000,
+                    -1050000
+                ]
+            }
+        },
+        "6c9b3f42-1a86-4f21-88dd-1742058d9fa9": {
+            "name": "A9B4",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2450000,
+                    4045000
+                ]
+            }
+        },
+        "715c32d6-94d8-49e8-9b43-e8899c6dd8b5": {
+            "name": "A12B1",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    3250000,
+                    4045000
+                ]
+            }
+        },
+        "730999af-3b26-4cf0-ab32-79051cd50e33": {
+            "name": "A6",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -250000,
+                    4045000
+                ]
+            }
+        },
+        "941d237f-68ef-4695-91b8-6b69e438b26f": {
+            "name": "A5",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -1250000,
+                    4045000
+                ]
+            }
+        },
+        "a62db483-9d34-49bd-9f7f-9bc3009f0589": {
+            "name": "A8",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    1250000,
+                    4045000
+                ]
+            }
+        },
+        "d230be10-3b20-4c5e-99b3-dad7ce3ea870": {
+            "name": "B8",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -1750000,
+                    4045000
+                ]
+            }
+        },
+        "e460c6fc-b4e3-4ceb-852f-3b6d0b5326f2": {
+            "name": "B5",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 300000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    1750000,
+                    4045000
+                ]
+            }
+        },
+        "ed1f1c0b-9cf5-4282-a867-cd51d7575fba": {
+            "name": "H1",
+            "padstack": "762c84c2-187d-454a-af81-d3381bec5257",
+            "parameter_set": {
+                "hole_diameter": 650000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2890000,
+                    2600000
+                ]
+            }
+        },
+        "f832186f-3df5-498e-9a5c-31f3bdb88370": {
+            "name": "H2",
+            "padstack": "762c84c2-187d-454a-af81-d3381bec5257",
+            "parameter_set": {
+                "hole_diameter": 650000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2890000,
+                    2600000
+                ]
+            }
+        },
+        "fe0f193a-129e-4896-bed0-9df5253bd0a1": {
+            "name": "A1B12",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 1450000,
+                "pad_width": 600000
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -3250000,
+                    4045000
+                ]
+            }
+        }
+    },
+    "parameter_program": "10.140mm 9.020mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.510mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "0ceda95e-e800-4de4-b6f8-2ca658406227": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5320000,
+                        -4250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -5320000,
+                        5270000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5320000,
+                        5270000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        5320000,
+                        -4250000
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "c86ccad6-1aa0-48af-80d8-13ed8b19d944": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4470000,
+                        3700000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -4470000,
+                        -3650000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4470000,
+                        -3650000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        4470000,
+                        3700000
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "rules": {
+        "clearance_package": {
+            "clearance_silkscreen_cu": 200000,
+            "clearance_silkscreen_pkg": 200000,
+            "enabled": true,
+            "order": -1
+        },
+        "package_checks": {
+            "enabled": true,
+            "order": -1
+        }
+    },
+    "tags": [
+        "connector",
+        "type-c",
+        "usb"
+    ],
+    "texts": {
+        "530835ab-7602-452d-811d-fc30ae6a16ca": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4700000,
+                    5830000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "68cba25d-e970-46de-86cf-aa0d5c2c5bd4": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -4440000,
+                    840000
+                ]
+            },
+            "size": 1500000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "60140683-1696-4d05-b70b-6b74f229dba8"
+}

--- a/packages/connector/usb/krhro/type-c-31-m-12/package.json
+++ b/packages/connector/usb/krhro/type-c-31-m-12/package.json
@@ -1,6 +1,6 @@
 {
     "arcs": {},
-    "default_model": "4cb5d3e5-f709-4be0-a41f-f357dfab2bff",
+    "default_model": "00000000-0000-0000-0000-000000000000",
     "dimensions": {},
     "grid_settings": {
         "current": {
@@ -156,17 +156,7 @@
         }
     },
     "manufacturer": "Korean Hroparts",
-    "models": {
-        "4cb5d3e5-f709-4be0-a41f-f357dfab2bff": {
-            "filename": "3d_models/connector/usb/HRO_TYPE-C-31-M-12.step",
-            "pitch": 0,
-            "roll": 0,
-            "x": -4475000,
-            "y": -3650000,
-            "yaw": 0,
-            "z": 100000
-        }
-    },
+    "models": {},
     "name": "TYPE-C-31-M-12",
     "pads": {
         "0eb110b0-8492-4998-92a9-5f54d197e77f": {

--- a/packages/connector/usb/krhro/type-c-31-m-12/package.json
+++ b/packages/connector/usb/krhro/type-c-31-m-12/package.json
@@ -1,6 +1,6 @@
 {
     "arcs": {},
-    "default_model": "00000000-0000-0000-0000-000000000000",
+    "default_model": "4cb5d3e5-f709-4be0-a41f-f357dfab2bff",
     "dimensions": {},
     "grid_settings": {
         "current": {
@@ -156,7 +156,17 @@
         }
     },
     "manufacturer": "Korean Hroparts",
-    "models": {},
+    "models": {
+        "4cb5d3e5-f709-4be0-a41f-f357dfab2bff": {
+            "filename": "3d_models/connector/usb/HRO_TYPE-C-31-M-12.step",
+            "pitch": 0,
+            "roll": 0,
+            "x": -4475000,
+            "y": -3650000,
+            "yaw": 0,
+            "z": 100000
+        }
+    },
     "name": "TYPE-C-31-M-12",
     "pads": {
         "0eb110b0-8492-4998-92a9-5f54d197e77f": {

--- a/parts/connector/usb/krhro/type-c-31-m-12.json
+++ b/parts/connector/usb/krhro/type-c-31-m-12.json
@@ -18,10 +18,7 @@
         false,
         "Korean Hroparts"
     ],
-    "model": "00000000-0000-0000-0000-000000000000",
-    "orderable_MPNs": {
-        "9f3be422-e69e-499f-b88b-35d4cdd7dc9e": "TYPE-C-31-M-12"
-    },
+    "model": "4cb5d3e5-f709-4be0-a41f-f357dfab2bff",
     "package": "60140683-1696-4d05-b70b-6b74f229dba8",
     "pad_map": {
         "0eb110b0-8492-4998-92a9-5f54d197e77f": {

--- a/parts/connector/usb/krhro/type-c-31-m-12.json
+++ b/parts/connector/usb/krhro/type-c-31-m-12.json
@@ -1,0 +1,104 @@
+{
+    "MPN": [
+        false,
+        "TYPE-C-31-M-12"
+    ],
+    "datasheet": [
+        false,
+        "http://www.krhro.com/uploads/soft/180320/1-1P320120243.pdf"
+    ],
+    "description": [
+        false,
+        "USB Type-C Receptacle for USB 2.0"
+    ],
+    "entity": "b3c7f10f-2160-4b68-a38b-10bf0263c097",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Korean Hroparts"
+    ],
+    "model": "63b43e86-0bef-4caf-ab6f-041ddf71db71",
+    "orderable_MPNs": {
+        "9f3be422-e69e-499f-b88b-35d4cdd7dc9e": "TYPE-C-31-M-12"
+    },
+    "package": "60140683-1696-4d05-b70b-6b74f229dba8",
+    "pad_map": {
+        "0eb110b0-8492-4998-92a9-5f54d197e77f": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "aee26174-f9f5-43a8-92e1-3ddf20d371b0"
+        },
+        "292a75f6-ca58-4c7c-a5ef-1b0835307998": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "b1c2ee2f-b8be-44c0-9561-79a5d9d6bc0b"
+        },
+        "35069a15-d76f-4067-8da9-c2e5830f2594": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "064529f5-6793-469d-8677-c79fcd871f28"
+        },
+        "37799a60-1ba1-43fe-a9de-8fcf009dfd8d": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "b1c2ee2f-b8be-44c0-9561-79a5d9d6bc0b"
+        },
+        "42d494d9-8c52-4442-acf2-21dcd7712353": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "aee26174-f9f5-43a8-92e1-3ddf20d371b0"
+        },
+        "53f29b72-b570-4a86-ba4f-d351aa74f4f5": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "aee26174-f9f5-43a8-92e1-3ddf20d371b0"
+        },
+        "685f9220-20a0-4286-9536-d0c97e871b2d": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "7a4448f5-517d-4ec6-97f7-aefcdf13e02d"
+        },
+        "6b646a4a-36f6-480c-b997-f62fa89e640e": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "aee26174-f9f5-43a8-92e1-3ddf20d371b0"
+        },
+        "6c9b3f42-1a86-4f21-88dd-1742058d9fa9": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "7a4448f5-517d-4ec6-97f7-aefcdf13e02d"
+        },
+        "715c32d6-94d8-49e8-9b43-e8899c6dd8b5": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "2717d9e3-9712-4526-8024-6efc1e8e0bc0"
+        },
+        "730999af-3b26-4cf0-ab32-79051cd50e33": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "064529f5-6793-469d-8677-c79fcd871f28"
+        },
+        "941d237f-68ef-4695-91b8-6b69e438b26f": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "f075d86c-b10a-412a-b49d-714cc3efcce7"
+        },
+        "a62db483-9d34-49bd-9f7f-9bc3009f0589": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "63d5899e-90d1-447c-9eaa-1eaf276e807c"
+        },
+        "d230be10-3b20-4c5e-99b3-dad7ce3ea870": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "8adefde6-f9b7-4fed-91ee-55089829bb93"
+        },
+        "e460c6fc-b4e3-4ceb-852f-3b6d0b5326f2": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "d9e315ef-20c5-40e4-98ab-e604063682b5"
+        },
+        "fe0f193a-129e-4896-bed0-9df5253bd0a1": {
+            "gate": "c8b7918e-fbf3-4d3d-9629-7888c2542a58",
+            "pin": "2717d9e3-9712-4526-8024-6efc1e8e0bc0"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "connector",
+        "type-c",
+        "usb"
+    ],
+    "type": "part",
+    "uuid": "69347855-3139-4fcb-a1ad-3b5649fe32d4",
+    "value": [
+        false,
+        ""
+    ]
+}

--- a/parts/connector/usb/krhro/type-c-31-m-12.json
+++ b/parts/connector/usb/krhro/type-c-31-m-12.json
@@ -18,7 +18,7 @@
         false,
         "Korean Hroparts"
     ],
-    "model": "63b43e86-0bef-4caf-ab6f-041ddf71db71",
+    "model": "00000000-0000-0000-0000-000000000000",
     "orderable_MPNs": {
         "9f3be422-e69e-499f-b88b-35d4cdd7dc9e": "TYPE-C-31-M-12"
     },
@@ -92,6 +92,7 @@
     "parametric": {},
     "tags": [
         "connector",
+        "smd",
         "type-c",
         "usb"
     ],


### PR DESCRIPTION
This is a USB 2.0 connector (no superspeed pins) from the same manufacturer as TYPE-C-31-M-30.
There are two versions of the datasheet: [the one on LCSC](https://datasheet.lcsc.com/lcsc/1811131825_Korean-Hroparts-Elec-TYPE-C-31-M-12_C165948.pdf) and [the one on the vendor's website](http://www.krhro.com/uploads/soft/180320/1-1P320120243.pdf) — the latter has a more detailed "recommended PCB layout" but the PDF is rotated (lol).

The footprint is kinda similar to DX07S016JA1R1500 but not really, so I've added one based on a KiCad import. The big pads are for two pins each (at least on the actual USB-C side) so I've called them "A1B12"/etc. in the footprint, I'm not sure what the best name would be (picking one of two feels ehhhhh not great, just inventing something like "VBUS1" "VBUS2" also I'm not sure about).

There is a 3D model [here](https://grabcad.com/library/type-c-31-m-12-1) but it's not explicitly licensed under compatible terms :/ (GrabCAD by default applies [a non-commercial-only license](https://grabcad.com/questions/what-type-of-license-governs-use-reuse-modifications-and-distribution-of-the-cad-files-on-grabcad))