### PR TITLE
Adding Instrumentation Amplifiers by Analog Devices

### DIFF
--- a/entities/ic/manufacturer/ad/AD620.json
+++ b/entities/ic/manufacturer/ad/AD620.json
@@ -1,0 +1,26 @@
+{
+    "gates": {
+        "6a103702-c217-455e-99c6-3a782da60008": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "80abde47-53fc-41b9-ba22-4c6847c7e02f"
+        },
+        "73841e6c-a44c-4f7b-83c5-4086128c9c53": {
+            "name": "Power",
+            "suffix": "P",
+            "swap_group": 0,
+            "unit": "c5b399c9-5626-4cc6-b33d-5c0f3da5df5c"
+        }
+    },
+    "manufacturer": "Analog Devices",
+    "name": "Instrumentation Amplifier with Ref out and setable Gain",
+    "prefix": "Q",
+    "tags": [
+        "amplifier",
+        "ic",
+        "instrumentation"
+    ],
+    "type": "entity",
+    "uuid": "4ff54c98-69b9-425f-8922-3e6dfa413b91"
+}

--- a/parts/ic/manufacturer/ad/AD620xN.json
+++ b/parts/ic/manufacturer/ad/AD620xN.json
@@ -1,0 +1,76 @@
+{
+    "MPN": [
+        false,
+        "AD620xN"
+    ],
+    "datasheet": [
+        false,
+        "https://www.analog.com/media/en/technical-documentation/data-sheets/ad620.pdf"
+    ],
+    "description": [
+        false,
+        "Low Power Instrumentation Amplifier"
+    ],
+    "entity": "4ff54c98-69b9-425f-8922-3e6dfa413b91",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Analog Devices"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "orderable_MPNs": {
+        "300b1bcb-7152-491c-b9b4-d2558a8f8169": "AD620BN",
+        "82fbfd68-297e-49bc-9680-0e2c541a21b4": "AD620BNZ",
+        "e017eb87-59f8-443f-85e0-ae7044508aaa": "AD620ANZ",
+        "ff73b472-8dbd-4c9d-bb4f-9a243d68f324": "AD620AN"
+    },
+    "package": "d39137d0-f433-40ab-872c-263c701420b0",
+    "pad_map": {
+        "17f96b52-6224-4156-a2c9-3b4c292bf3ab": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "f13f6633-980e-41df-8b97-d8955639c6d3"
+        },
+        "49b2ec1d-bc9c-4e02-938e-5853ed60855c": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "deca1fe8-7952-4881-82ff-a00f051557f6"
+        },
+        "4f957a10-9981-4100-ae71-aeff3c5066d1": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "e400cb93-b0da-496f-84a2-fc62e8e84ca5"
+        },
+        "69825f2f-88b4-4724-8e7c-f72589e2c0c7": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "74fe94c2-657f-4184-b5fe-e70be607ce0d": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "ff7319f3-c1bc-48cf-b15a-15d033e45fc9"
+        },
+        "7f96be97-4c27-449b-85d4-982e9acc4e0f": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "82c78305-002b-487c-b1b6-b33435718f8e": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "b564dd19-20b9-4851-a5fd-def5f784c8c2"
+        },
+        "ef232360-f78f-4226-921e-ec90c9f38e0a": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "24f69a2b-b10c-43ba-aa0f-1245e69cd0c4"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "amplifier",
+        "dip-8",
+        "ic",
+        "instrumentation"
+    ],
+    "type": "part",
+    "uuid": "b73265c6-e0a3-42ff-b4c2-abf4a1cf20db",
+    "value": [
+        false,
+        "AD620"
+    ]
+}

--- a/parts/ic/manufacturer/ad/AD620xR.json
+++ b/parts/ic/manufacturer/ad/AD620xR.json
@@ -1,0 +1,76 @@
+{
+    "MPN": [
+        false,
+        "AD620xR"
+    ],
+    "datasheet": [
+        false,
+        "https://www.analog.com/media/en/technical-documentation/data-sheets/ad620.pdf"
+    ],
+    "description": [
+        false,
+        "Low Power Instrumentation Amplifier"
+    ],
+    "entity": "4ff54c98-69b9-425f-8922-3e6dfa413b91",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Analog Devices"
+    ],
+    "model": "b99785a3-c0da-4658-969d-6287cec3be05",
+    "orderable_MPNs": {
+        "b3401f92-4b0e-4618-b949-3d6c8e5e820e": "AD620AR",
+        "b7a89992-7842-42db-bc87-68fb6f7154dc": "AD620ARZ",
+        "cecbc160-7433-4a38-981d-0f24bff91942": "AD620BR",
+        "eb528a4a-0f84-47da-b88b-67757dac29ea": "AD620BRZ"
+    },
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "deca1fe8-7952-4881-82ff-a00f051557f6"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "b564dd19-20b9-4851-a5fd-def5f784c8c2"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "24f69a2b-b10c-43ba-aa0f-1245e69cd0c4"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "e400cb93-b0da-496f-84a2-fc62e8e84ca5"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "f13f6633-980e-41df-8b97-d8955639c6d3"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "ff7319f3-c1bc-48cf-b15a-15d033e45fc9"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "amplifier",
+        "ic",
+        "instrumentation",
+        "soic-8"
+    ],
+    "type": "part",
+    "uuid": "4c4798c7-4f42-49b6-b9f7-ea170eb99a25",
+    "value": [
+        false,
+        "AD620"
+    ]
+}

--- a/parts/ic/manufacturer/ad/AD8221xR.json
+++ b/parts/ic/manufacturer/ad/AD8221xR.json
@@ -1,0 +1,76 @@
+{
+    "MPN": [
+        false,
+        "AD8221xR"
+    ],
+    "datasheet": [
+        false,
+        "https://www.analog.com/media/en/technical-documentation/data-sheets/AD8221.pdf"
+    ],
+    "description": [
+        false,
+        "Precision Instrumentation Amplifier"
+    ],
+    "entity": "4ff54c98-69b9-425f-8922-3e6dfa413b91",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Analog Devices"
+    ],
+    "model": "b99785a3-c0da-4658-969d-6287cec3be05",
+    "orderable_MPNs": {
+        "148b9ab8-298d-4e25-ac23-e4361a9a8836": "AD8221AR",
+        "289a9616-56d7-4d89-b567-3cef82020ac5": "AD8221BR",
+        "e9afef00-03d6-4454-a649-3d1edd45f14c": "AD8221BRZ",
+        "f38e802a-cb08-4766-a0ec-5e6d8f0d396f": "AD8221ARZ"
+    },
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "b564dd19-20b9-4851-a5fd-def5f784c8c2"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "24f69a2b-b10c-43ba-aa0f-1245e69cd0c4"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "f13f6633-980e-41df-8b97-d8955639c6d3"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "deca1fe8-7952-4881-82ff-a00f051557f6"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "ff7319f3-c1bc-48cf-b15a-15d033e45fc9"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "e400cb93-b0da-496f-84a2-fc62e8e84ca5"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "amplifier",
+        "ic",
+        "instrumentation",
+        "soic-8"
+    ],
+    "type": "part",
+    "uuid": "5fb04cb9-671e-4a94-9910-947093922d33",
+    "value": [
+        false,
+        "AD8221"
+    ]
+}

--- a/parts/ic/manufacturer/ad/AD8226xR.json
+++ b/parts/ic/manufacturer/ad/AD8226xR.json
@@ -1,0 +1,75 @@
+{
+    "MPN": [
+        false,
+        "AD8226xR"
+    ],
+    "datasheet": [
+        false,
+        "https://www.analog.com/media/en/technical-documentation/data-sheets/AD8226.pdf"
+    ],
+    "description": [
+        false,
+        "Wide Supply Range, Rail-to-Rail Output Instrumentation Amplifier"
+    ],
+    "entity": "4ff54c98-69b9-425f-8922-3e6dfa413b91",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Analog Devices"
+    ],
+    "model": "b99785a3-c0da-4658-969d-6287cec3be05",
+    "orderable_MPNs": {
+        "55a0afc8-642a-4e84-9784-4314f20e91f3": "AD8226BRZ",
+        "e5bbf800-f070-4064-b06f-a231b17872e8": "AD8226ARZ"
+    },
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "b564dd19-20b9-4851-a5fd-def5f784c8c2"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "24f69a2b-b10c-43ba-aa0f-1245e69cd0c4"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "f13f6633-980e-41df-8b97-d8955639c6d3"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "deca1fe8-7952-4881-82ff-a00f051557f6"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "ff7319f3-c1bc-48cf-b15a-15d033e45fc9"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "e400cb93-b0da-496f-84a2-fc62e8e84ca5"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "amplifier",
+        "ic",
+        "instrumentation",
+        "rail-to-rail",
+        "soic-8"
+    ],
+    "type": "part",
+    "uuid": "6b45bdd5-3beb-4801-88cb-a36a99dc8394",
+    "value": [
+        false,
+        "AD8226"
+    ]
+}

--- a/parts/ic/manufacturer/ad/AD8429xR.json
+++ b/parts/ic/manufacturer/ad/AD8429xR.json
@@ -1,0 +1,75 @@
+{
+    "MPN": [
+        false,
+        "AD8429xR"
+    ],
+    "datasheet": [
+        false,
+        "https://www.analog.com/media/en/technical-documentation/data-sheets/AD8429.pdf"
+    ],
+    "description": [
+        false,
+        "Low Noise Instrumentation Amplifier"
+    ],
+    "entity": "4ff54c98-69b9-425f-8922-3e6dfa413b91",
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Analog Devices"
+    ],
+    "model": "b99785a3-c0da-4658-969d-6287cec3be05",
+    "orderable_MPNs": {
+        "8d1d17b8-9e4e-4474-8a32-e3892b75dac6": "AD8429ARZ",
+        "e92d2d02-cd22-4bf2-bdd2-f7fd8e86c381": "AD8429BRZ"
+    },
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "b564dd19-20b9-4851-a5fd-def5f784c8c2"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "24f69a2b-b10c-43ba-aa0f-1245e69cd0c4"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "f13f6633-980e-41df-8b97-d8955639c6d3"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "deca1fe8-7952-4881-82ff-a00f051557f6"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "ff7319f3-c1bc-48cf-b15a-15d033e45fc9"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "aacf2d55-cf04-4c20-89c5-61704ef771f7"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "6a103702-c217-455e-99c6-3a782da60008",
+            "pin": "e400cb93-b0da-496f-84a2-fc62e8e84ca5"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "73841e6c-a44c-4f7b-83c5-4086128c9c53",
+            "pin": "a8ba387d-1c68-4215-843f-9d669e48646d"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "amplifier",
+        "ic",
+        "instrumentation",
+        "low-noise",
+        "soic-8"
+    ],
+    "type": "part",
+    "uuid": "2fedd34e-8437-4e43-9286-7fa51c3ca989",
+    "value": [
+        false,
+        "AD8429"
+    ]
+}

--- a/symbols/ic/manufacturer/ad/AD620.json
+++ b/symbols/ic/manufacturer/ad/AD620.json
@@ -1,0 +1,190 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "05c2c6ab-95ea-41ff-8785-291f79cb81ee": {
+            "position": [
+                -12500000,
+                13750000
+            ]
+        },
+        "39e670ec-53ef-4009-b68c-0e10ef4be217": {
+            "position": [
+                -12500000,
+                -13750000
+            ]
+        },
+        "75d96134-0bff-4f58-a8be-94061a72da79": {
+            "position": [
+                12500000,
+                0
+            ]
+        }
+    },
+    "lines": {
+        "1653eab6-6554-43bf-90bb-926e6640a839": {
+            "from": "75d96134-0bff-4f58-a8be-94061a72da79",
+            "layer": 0,
+            "to": "39e670ec-53ef-4009-b68c-0e10ef4be217",
+            "width": 0
+        },
+        "59e97cb9-3364-4d06-8291-568ac7fd76a3": {
+            "from": "39e670ec-53ef-4009-b68c-0e10ef4be217",
+            "layer": 0,
+            "to": "05c2c6ab-95ea-41ff-8785-291f79cb81ee",
+            "width": 0
+        },
+        "954f3465-254e-4a4d-9535-74e995d41377": {
+            "from": "05c2c6ab-95ea-41ff-8785-291f79cb81ee",
+            "layer": 0,
+            "to": "75d96134-0bff-4f58-a8be-94061a72da79",
+            "width": 0
+        }
+    },
+    "name": "Instrumentation Amplifier with Ref out and setable Gain",
+    "pins": {
+        "24f69a2b-b10c-43ba-aa0f-1245e69cd0c4": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                10000000
+            ]
+        },
+        "b564dd19-20b9-4851-a5fd-def5f784c8c2": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                5000000
+            ]
+        },
+        "deca1fe8-7952-4881-82ff-a00f051557f6": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                -10000000
+            ]
+        },
+        "e400cb93-b0da-496f-84a2-fc62e8e84ca5": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2800000,
+            "name_orientation": "horizontal",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                6250000,
+                -6250000
+            ]
+        },
+        "f13f6633-980e-41df-8b97-d8955639c6d3": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                15000000,
+                0
+            ]
+        },
+        "ff7319f3-c1bc-48cf-b15a-15d033e45fc9": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -15000000,
+                -5000000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {},
+    "texts": {
+        "3162ff3e-c32f-4ee6-aa61-68583cb7206a": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5000000,
+                    -12500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        },
+        "6033287e-090f-43bd-903c-695e5adf27f1": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5000000,
+                    12500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "80abde47-53fc-41b9-ba22-4c6847c7e02f",
+    "uuid": "ad7b9be7-8934-424e-9703-fcd06792c209"
+}

--- a/units/ic/manufacturer/ad/AD620.json
+++ b/units/ic/manufacturer/ad/AD620.json
@@ -1,0 +1,44 @@
+{
+    "manufacturer": "Analog Devices",
+    "name": "Instrumentation Amplifier with Ref out and setable Gain",
+    "pins": {
+        "24f69a2b-b10c-43ba-aa0f-1245e69cd0c4": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "+",
+            "swap_group": 0
+        },
+        "b564dd19-20b9-4851-a5fd-def5f784c8c2": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "RG1",
+            "swap_group": 0
+        },
+        "deca1fe8-7952-4881-82ff-a00f051557f6": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "-",
+            "swap_group": 0
+        },
+        "e400cb93-b0da-496f-84a2-fc62e8e84ca5": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "Ref",
+            "swap_group": 0
+        },
+        "f13f6633-980e-41df-8b97-d8955639c6d3": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "Out",
+            "swap_group": 0
+        },
+        "ff7319f3-c1bc-48cf-b15a-15d033e45fc9": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "RG2",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "80abde47-53fc-41b9-ba22-4c6847c7e02f"
+}


### PR DESCRIPTION
This adds multiple instrumentation amplifiers by Analog Devices, as well as a unit, entity and symbol for similar instrumentation amplifiers with a gain resistor and a reference output.

All DIP/SOIC instrumentation amplifiers by AD have been added, parts where the package was missing in the official pool (e.g. MSOP) have been skipped.