### PR TITLE
Fix the orientation of text in MOSFET symbols

### DIFF
--- a/symbols/transistor/mosfet-n.json
+++ b/symbols/transistor/mosfet-n.json
@@ -378,43 +378,43 @@
         },
         "180m": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    -3125000
+                    1625000,
+                    -4000000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    -625000
+                    -500000,
+                    -125000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 32768,
+                "mirror": true,
                 "shift": [
                     5000000,
-                    -1250000
+                    1375000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 32768,
+                "mirror": true,
                 "shift": [
                     5000000,
-                    1250000
+                    -1125000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    3125000
+                    1625000,
+                    4000000
                 ]
             }
         },
@@ -436,19 +436,19 @@
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 32768,
+                "mirror": true,
                 "shift": [
                     5000000,
-                    -1250000
+                    1375000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 32768,
+                "mirror": true,
                 "shift": [
                     5000000,
-                    1250000
+                    -1125000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
@@ -462,169 +462,169 @@
         },
         "270m": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    -3125000
+                    3375000,
+                    -3750000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    -625000
+                    -500000,
+                    -125000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 49152,
+                "mirror": true,
                 "shift": [
-                    5000000,
-                    -1250000
+                    8750000,
+                    5000000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    6250000,
+                    5000000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    3125000
+                    3375000,
+                    2875000
                 ]
             }
         },
         "270n": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    -3125000
+                    3375000,
+                    -3750000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    -625000
+                    -500000,
+                    -125000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    -1250000
+                    8750000,
+                    -5000000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    6250000,
+                    -5000000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    3125000
+                    3375000,
+                    2875000
                 ]
             }
         },
         "90m": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    -3750000
+                    1625000,
+                    -4000000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    -625000
+                    -500000,
+                    -125000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 16384,
+                "mirror": true,
                 "shift": [
-                    5000000,
-                    -1250000
+                    -3250000,
+                    3750000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    -750000,
+                    3750000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    3750000
+                    1625000,
+                    4000000
                 ]
             }
         },
         "90n": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    -3750000
+                    1625000,
+                    -4000000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    -625000
+                    -500000,
+                    -125000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    -1250000
+                    -4000000,
+                    -3125000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    -1500000,
+                    -3125000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    3750000
+                    1625000,
+                    4000000
                 ]
             }
         }
@@ -636,11 +636,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    -3125000
+                    3375000,
+                    -3750000
                 ]
             },
             "size": 750000,
@@ -653,11 +653,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    -625000
+                    -500000,
+                    -125000
                 ]
             },
             "size": 750000,
@@ -670,11 +670,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 49152,
+                "mirror": true,
                 "shift": [
-                    5000000,
-                    -1250000
+                    8750000,
+                    5000000
                 ]
             },
             "size": 1500000,
@@ -687,11 +687,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    6250000,
+                    5000000
                 ]
             },
             "size": 1500000,
@@ -704,11 +704,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    3125000
+                    3375000,
+                    2875000
                 ]
             },
             "size": 750000,

--- a/symbols/transistor/mosfet-p.json
+++ b/symbols/transistor/mosfet-p.json
@@ -400,19 +400,19 @@
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    5000000,
-                    -1250000
-                ]
-            },
-            "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 32768,
+                "mirror": true,
                 "shift": [
                     5000000,
                     1250000
+                ]
+            },
+            "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    5000000,
+                    -1250000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
@@ -442,19 +442,19 @@
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
-                "shift": [
-                    5000000,
-                    -1250000
-                ]
-            },
-            "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 32768,
+                "mirror": true,
                 "shift": [
                     5000000,
                     1250000
+                ]
+            },
+            "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
+                "angle": 32768,
+                "mirror": true,
+                "shift": [
+                    5000000,
+                    -1250000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
@@ -468,169 +468,169 @@
         },
         "270m": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    3125000
+                    3375000,
+                    3500000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    625000
+                    -375000,
+                    875000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 49152,
+                "mirror": true,
                 "shift": [
-                    5000000,
-                    -1250000
+                    8750000,
+                    5000000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 49152,
+                "mirror": true,
                 "shift": [
-                    5000000,
-                    1250000
+                    6250000,
+                    5000000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    -3125000
+                    3375000,
+                    -2875000
                 ]
             }
         },
         "270n": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    3125000
+                    3375000,
+                    3500000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    625000
+                    -375000,
+                    875000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    -1250000
+                    8750000,
+                    -5000000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    6250000,
+                    -5000000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    -3125000
+                    3375000,
+                    -2875000
                 ]
             }
         },
         "90m": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    3750000
+                    1625000,
+                    4000000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    625000
+                    -375000,
+                    875000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
-                "mirror": false,
+                "angle": 16384,
+                "mirror": true,
                 "shift": [
-                    5000000,
-                    -1250000
+                    -3750000,
+                    3750000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
+                "angle": 16384,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    -1250000,
+                    3750000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    -3750000
+                    1625000,
+                    -3250000
                 ]
             }
         },
         "90n": {
             "2a353f04-6c1b-4966-8500-dc320a1767e9": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    3750000
+                    1625000,
+                    4000000
                 ]
             },
             "65a021e3-b30a-4ca3-b6d5-e19223b66aa0": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    625000
+                    -375000,
+                    750000
                 ]
             },
             "8b0adc2a-60f6-40cf-9dd2-53000c15c5c1": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    -1250000
+                    -5000000,
+                    -2500000
                 ]
             },
             "8ec24f64-8ff4-45bb-9d42-3bc510af1597": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    -2500000,
+                    -2500000
                 ]
             },
             "add8fc4f-ae82-4347-b534-673d24c1f6dc": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    1375000,
-                    -3750000
+                    1625000,
+                    -3250000
                 ]
             }
         }
@@ -642,11 +642,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    3125000
+                    1625000,
+                    4000000
                 ]
             },
             "size": 750000,
@@ -659,11 +659,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    -875000,
-                    625000
+                    -375000,
+                    750000
                 ]
             },
             "size": 750000,
@@ -676,11 +676,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    -1250000
+                    -5000000,
+                    -2500000
                 ]
             },
             "size": 1500000,
@@ -693,11 +693,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    5000000,
-                    1250000
+                    -2500000,
+                    -2500000
                 ]
             },
             "size": 1500000,
@@ -710,11 +710,11 @@
             "layer": 0,
             "origin": "center",
             "placement": {
-                "angle": 0,
+                "angle": 49152,
                 "mirror": false,
                 "shift": [
-                    2875000,
-                    -3125000
+                    1625000,
+                    -3250000
                 ]
             },
             "size": 750000,


### PR DESCRIPTION
After looking at the screenshots of the previous PR for a bit, I realized that I probably needed to fix the orientation of other text as well — so here it is.
![Screenshot from 2022-07-24 01-37-50](https://user-images.githubusercontent.com/483682/180612113-ce30ab40-f4ab-4b63-883a-73673ebdc6b5.png)
![Screenshot from 2022-07-24 01-38-01](https://user-images.githubusercontent.com/483682/180612117-098d9242-c62a-405b-9cdb-625789fb0190.png)

