### PR TITLE
Add Texas Instruments ADS101x ADCs

### DIFF
--- a/entities/ic/adc/ti/ADS101x.json
+++ b/entities/ic/adc/ti/ADS101x.json
@@ -1,0 +1,19 @@
+{
+    "gates": {
+        "fabe58f7-ba88-4dfa-a17c-9932387834fe": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "a3d29515-8422-4d40-83d1-fbd099c34d1e"
+        }
+    },
+    "manufacturer": "Texas Instruments",
+    "name": "ADS101x",
+    "prefix": "U",
+    "tags": [
+        "adc",
+        "ic"
+    ],
+    "type": "entity",
+    "uuid": "6589d0e1-ae31-4a5b-97e0-996599c83182"
+}

--- a/packages/manufacturer/ti/dgs-10/package.json
+++ b/packages/manufacturer/ti/dgs-10/package.json
@@ -1,0 +1,507 @@
+{
+    "arcs": {},
+    "default_model": "3c0fc0fa-412c-49e7-bbc1-ac604600b982",
+    "dimensions": {},
+    "grid_settings": {
+        "current": {
+            "mode": "square",
+            "name": "",
+            "origin": [
+                0,
+                0
+            ],
+            "spacing_rect": [
+                1000000,
+                1000000
+            ],
+            "spacing_square": 1000000
+        },
+        "grids": {}
+    },
+    "junctions": {
+        "0c1e19e2-0d04-4cb9-9478-baf2a2956e45": {
+            "position": [
+                1876400,
+                -1876400
+            ]
+        },
+        "0c226bd9-8225-4f04-8470-ab8c7d454a1f": {
+            "position": [
+                1876400,
+                1876400
+            ]
+        },
+        "0d88f24f-deea-4ce0-81cc-cf07899a3694": {
+            "position": [
+                -1876400,
+                -1472441
+            ]
+        },
+        "0e383def-e962-4d7a-86b5-277714b3bb2b": {
+            "position": [
+                1876400,
+                -1472441
+            ]
+        },
+        "5634b630-42c7-47d1-adae-3be0ab905472": {
+            "position": [
+                1876400,
+                1472441
+            ]
+        },
+        "ce715c47-7e75-40dc-ae6d-7d2e44bd7c91": {
+            "position": [
+                -1876400,
+                1876400
+            ]
+        },
+        "d2061694-779b-4752-837a-f5ba646704c2": {
+            "position": [
+                -1876400,
+                -1876400
+            ]
+        },
+        "d4e59670-4413-4925-a758-c507414c2ea0": {
+            "position": [
+                -1876400,
+                1472441
+            ]
+        }
+    },
+    "keepouts": {},
+    "lines": {
+        "1945d9cf-e385-454f-9238-2970530e0cdb": {
+            "from": "5634b630-42c7-47d1-adae-3be0ab905472",
+            "layer": 20,
+            "to": "0c226bd9-8225-4f04-8470-ab8c7d454a1f",
+            "width": 120000
+        },
+        "44b435e1-b61f-4dd9-af54-608f01860b48": {
+            "from": "0c226bd9-8225-4f04-8470-ab8c7d454a1f",
+            "layer": 20,
+            "to": "ce715c47-7e75-40dc-ae6d-7d2e44bd7c91",
+            "width": 120000
+        },
+        "6fc31a47-2509-45b2-a707-313f9dfbd9c6": {
+            "from": "0c1e19e2-0d04-4cb9-9478-baf2a2956e45",
+            "layer": 20,
+            "to": "0e383def-e962-4d7a-86b5-277714b3bb2b",
+            "width": 120000
+        },
+        "932a5385-a5c9-4f75-b305-21334b63c97c": {
+            "from": "0d88f24f-deea-4ce0-81cc-cf07899a3694",
+            "layer": 20,
+            "to": "d2061694-779b-4752-837a-f5ba646704c2",
+            "width": 120000
+        },
+        "a008ac4a-2e2f-4210-94bc-867df7f2c96c": {
+            "from": "ce715c47-7e75-40dc-ae6d-7d2e44bd7c91",
+            "layer": 20,
+            "to": "d4e59670-4413-4925-a758-c507414c2ea0",
+            "width": 120000
+        },
+        "c08d0a7b-b11c-4e93-aaef-b898b09d86df": {
+            "from": "d2061694-779b-4752-837a-f5ba646704c2",
+            "layer": 20,
+            "to": "0c1e19e2-0d04-4cb9-9478-baf2a2956e45",
+            "width": 120000
+        }
+    },
+    "manufacturer": "Texas Instruments",
+    "models": {
+        "3c0fc0fa-412c-49e7-bbc1-ac604600b982": {
+            "filename": "3d_models/manufacturer/ti/DGS0010A.stp",
+            "pitch": 16384,
+            "roll": 49152,
+            "x": 0,
+            "y": 0,
+            "yaw": 0,
+            "z": 700000
+        }
+    },
+    "name": "DGS10",
+    "pads": {
+        "3b537d5e-b754-4a8d-9ce8-c989e1ae2bd6": {
+            "name": "3",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2213348,
+                    0
+                ]
+            }
+        },
+        "4fa9a149-7466-40a7-9bc6-b41c3b8779d5": {
+            "name": "10",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2213348,
+                    1000000
+                ]
+            }
+        },
+        "52a7f3b7-ed72-4719-97c8-d2b9c1507bc9": {
+            "name": "5",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2213348,
+                    -1000000
+                ]
+            }
+        },
+        "5d8ccd02-1f0c-4555-afed-6e7ae8b19e57": {
+            "name": "2",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2213348,
+                    499999
+                ]
+            }
+        },
+        "8cf4d0ba-c25b-45e1-aca9-21fa89d744bb": {
+            "name": "1",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2213348,
+                    1000000
+                ]
+            }
+        },
+        "a94f15ce-3510-4eca-8e1e-5f8eb185b131": {
+            "name": "6",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2213348,
+                    -1000000
+                ]
+            }
+        },
+        "d93f26b2-caca-4c80-bbc0-d5bd5a639da4": {
+            "name": "8",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2213348,
+                    0
+                ]
+            }
+        },
+        "e0ea12bc-b71f-4d3d-8d5d-8bc2415ae1ba": {
+            "name": "9",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2213348,
+                    499999
+                ]
+            }
+        },
+        "e33337ef-bfef-45ce-a925-48d9fa796a86": {
+            "name": "4",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -2213348,
+                    -499999
+                ]
+            }
+        },
+        "ffb389ee-9b1e-40ee-a0ad-1a56382bfa84": {
+            "name": "7",
+            "padstack": "3846f4bf-7acf-403a-bc36-771ec675eac9",
+            "parameter_set": {
+                "pad_height": 279400,
+                "pad_width": 1327899
+            },
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    2213348,
+                    -499999
+                ]
+            }
+        }
+    },
+    "parameter_program": "5.755mm 3.099mm\nget-parameter [ courtyard_expansion ]\n2 * +xy\nset-polygon [ courtyard rectangle 0.000mm 0.000mm ]",
+    "parameter_set": {
+        "courtyard_expansion": 250000
+    },
+    "polygons": {
+        "2deab30f-1d6d-4e04-8dfd-8bcfd1764249": {
+            "layer": 40,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1549400,
+                        -1549400
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1549400,
+                        1549400
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1549400,
+                        1549400
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1549400,
+                        -1549400
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "482c3c47-03d3-4a60-bba8-45cc5ea6093e": {
+            "layer": 50,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1549400,
+                        -1549400
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -1549400,
+                        1549400
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1549400,
+                        1549400
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        1549400,
+                        -1549400
+                    ],
+                    "type": "line"
+                }
+            ]
+        },
+        "efdfb92d-cb10-4638-bd66-a30d880266ab": {
+            "layer": 60,
+            "parameter_class": "courtyard",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3127500,
+                        -1799500
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -3127500,
+                        1799500
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3127500,
+                        1799500
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        3127500,
+                        -1799500
+                    ],
+                    "type": "line"
+                }
+            ]
+        }
+    },
+    "rules": {
+        "clearance_package": {
+            "clearance_silkscreen_cu": 200000,
+            "clearance_silkscreen_pkg": 200000,
+            "enabled": true,
+            "order": -1
+        },
+        "package_checks": {
+            "enabled": true,
+            "order": -1
+        }
+    },
+    "tags": [
+        "ic",
+        "smd"
+    ],
+    "texts": {
+        "81e8f1ce-3f5e-488c-9609-eeda4f8d81d9": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 20,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -1500000,
+                    3000000
+                ]
+            },
+            "size": 1000000,
+            "text": "$RD",
+            "width": 150000
+        },
+        "c0216461-9642-4721-bca0-82fc06786e87": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 50,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -1000000,
+                    0
+                ]
+            },
+            "size": 500000,
+            "text": "$RD",
+            "width": 0
+        }
+    },
+    "type": "package",
+    "uuid": "6a695d42-ae11-4034-afb2-37106739dfc9"
+}

--- a/parts/ic/adc/ti/ADS1013IDGS.json
+++ b/parts/ic/adc/ti/ADS1013IDGS.json
@@ -1,0 +1,34 @@
+{
+    "MPN": [
+        false,
+        "ADS1013IDGS"
+    ],
+    "base": "78e8e8de-7c2f-43fa-a40b-7cc10a2ce72b",
+    "datasheet": [
+        true,
+        "https://www.ti.com/lit/gpn/ads1015"
+    ],
+    "description": [
+        false,
+        "12-Bit 3.3kSPS 1-Ch Delta-Sigma ADC With Oscillator, Voltage Reference, and I2C"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "3c0fc0fa-412c-49e7-bbc1-ac604600b982",
+    "orderable_MPNs": {
+        "0b64aad2-59fb-4556-b8f3-2ce9c7d32730": "ADS1013IDGST",
+        "19f22add-104c-45cf-95df-4f167fa1665a": "ADS1013IDGSR"
+    },
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "b395f3a5-a99e-4db9-86d8-124b198f3247",
+    "value": [
+        true,
+        "ADS101x"
+    ]
+}

--- a/parts/ic/adc/ti/ADS1014IDGS.json
+++ b/parts/ic/adc/ti/ADS1014IDGS.json
@@ -1,0 +1,34 @@
+{
+    "MPN": [
+        false,
+        "ADS1014IDGS"
+    ],
+    "base": "78e8e8de-7c2f-43fa-a40b-7cc10a2ce72b",
+    "datasheet": [
+        true,
+        "https://www.ti.com/lit/gpn/ads1015"
+    ],
+    "description": [
+        false,
+        "12-Bit 3.3kSPS 1-Ch Delta-Sigma ADC With PGA, Oscillator, Voltage Reference, Comparator, and I2C"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "3c0fc0fa-412c-49e7-bbc1-ac604600b982",
+    "orderable_MPNs": {
+        "0ade693d-c1e1-433e-8e4c-b3562a50af82": "ADS1014IDGST",
+        "1c5ebd85-00e4-4076-b261-eb34b59d38b6": "ADS1014IDGSR"
+    },
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "389807c5-5ba6-4f9d-a9ec-3620a20eb228",
+    "value": [
+        true,
+        "ADS101x"
+    ]
+}

--- a/parts/ic/adc/ti/ADS1015IDGS.json
+++ b/parts/ic/adc/ti/ADS1015IDGS.json
@@ -1,0 +1,34 @@
+{
+    "MPN": [
+        false,
+        "ADS1015IDGS"
+    ],
+    "base": "78e8e8de-7c2f-43fa-a40b-7cc10a2ce72b",
+    "datasheet": [
+        true,
+        "https://www.ti.com/lit/gpn/ads1015"
+    ],
+    "description": [
+        false,
+        "12-bit, 3.3-kSPS, 4-channel, delta-sigma ADC with PGA, oscillator, VREF, comparator and I2C"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Texas Instruments"
+    ],
+    "model": "3c0fc0fa-412c-49e7-bbc1-ac604600b982",
+    "orderable_MPNs": {
+        "01ecaa75-c596-4e4c-abcd-d08e62d1d2b5": "ADS1015IDGSR",
+        "5af537f2-ae5a-4c5d-ba3d-c81ca783fde2": "ADS1015IDGST"
+    },
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "cd17f3ad-707a-4ae9-81db-2b5202be1141",
+    "value": [
+        true,
+        "ADS101x"
+    ]
+}

--- a/parts/ic/adc/ti/ADS101xIDGS.json
+++ b/parts/ic/adc/ti/ADS101xIDGS.json
@@ -1,0 +1,82 @@
+{
+    "MPN": [
+        false,
+        "ADS101xIDGS"
+    ],
+    "datasheet": [
+        false,
+        "https://www.ti.com/lit/gpn/ads1015"
+    ],
+    "description": [
+        false,
+        "Ultra-Small, Low-Power, I2C-Compatible, 3.3-kSPS, 12-Bit ADCs With Internal Reference, Oscillator, and Programmable Comparator"
+    ],
+    "entity": "6589d0e1-ae31-4a5b-97e0-996599c83182",
+    "flags": {
+        "base_part": "set",
+        "exclude_bom": "clear",
+        "exclude_pnp": "clear"
+    },
+    "inherit_model": false,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Texas Instruments"
+    ],
+    "model": "3c0fc0fa-412c-49e7-bbc1-ac604600b982",
+    "package": "6a695d42-ae11-4034-afb2-37106739dfc9",
+    "pad_map": {
+        "3b537d5e-b754-4a8d-9ce8-c989e1ae2bd6": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "cebce729-e05b-485c-94a6-886b38a64db2"
+        },
+        "4fa9a149-7466-40a7-9bc6-b41c3b8779d5": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "007b1986-ef61-4c37-a4ad-cce2413b5f62"
+        },
+        "52a7f3b7-ed72-4719-97c8-d2b9c1507bc9": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "085aeeaf-6746-422d-91bc-256b2b9a3997"
+        },
+        "5d8ccd02-1f0c-4555-afed-6e7ae8b19e57": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "d726824b-5ea5-4478-935d-031798694406"
+        },
+        "8cf4d0ba-c25b-45e1-aca9-21fa89d744bb": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "5942f84d-3a88-46ea-8085-1c42dc092ed1"
+        },
+        "a94f15ce-3510-4eca-8e1e-5f8eb185b131": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "047ed370-f9fd-451e-9d05-50d44daaba30"
+        },
+        "d93f26b2-caca-4c80-bbc0-d5bd5a639da4": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "cc0095f2-e203-44e4-9ae5-fe2774480579"
+        },
+        "e0ea12bc-b71f-4d3d-8d5d-8bc2415ae1ba": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "8d22aa83-fcb0-4427-b5bc-969a255747f4"
+        },
+        "e33337ef-bfef-45ce-a925-48d9fa796a86": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "190fcf2e-cd47-431c-8c2f-c862bfcf4510"
+        },
+        "ffb389ee-9b1e-40ee-a0ad-1a56382bfa84": {
+            "gate": "fabe58f7-ba88-4dfa-a17c-9932387834fe",
+            "pin": "8a43adea-296d-4851-8ba5-fc684a57244e"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "adc",
+        "ic"
+    ],
+    "type": "part",
+    "uuid": "78e8e8de-7c2f-43fa-a40b-7cc10a2ce72b",
+    "value": [
+        false,
+        ""
+    ],
+    "version": 1
+}

--- a/symbols/ic/adc/ti/ADS101x.json
+++ b/symbols/ic/adc/ti/ADS101x.json
@@ -1,0 +1,294 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "0c648894-1db5-485a-8e13-6ea1a0376422": {
+            "position": [
+                -27500000,
+                -10000000
+            ]
+        },
+        "13f4d600-df5b-4aab-b08e-06648be94fe6": {
+            "position": [
+                27500000,
+                10000000
+            ]
+        },
+        "3364e9fa-46e6-4453-b79e-66a1e57c4bac": {
+            "position": [
+                -27500000,
+                10000000
+            ]
+        },
+        "3da3743d-12d6-4aa6-8a7d-61cfa7cf46c9": {
+            "position": [
+                -27500000,
+                10000000
+            ]
+        },
+        "5e3fb670-ade5-42ef-ace3-56fb38951ba8": {
+            "position": [
+                27500000,
+                -10000000
+            ]
+        },
+        "81098d67-14de-40a9-9b3e-a0f19dd406d6": {
+            "position": [
+                27500000,
+                10000000
+            ]
+        },
+        "a458d355-8c81-44e8-b3da-3421d2c8beea": {
+            "position": [
+                27500000,
+                -10000000
+            ]
+        },
+        "ca56e0d6-a15d-4ed8-9fea-ab17aa0af793": {
+            "position": [
+                -27500000,
+                -10000000
+            ]
+        }
+    },
+    "lines": {
+        "49607bbb-1d1e-49e1-8397-5fcd655b942f": {
+            "from": "0c648894-1db5-485a-8e13-6ea1a0376422",
+            "layer": 0,
+            "to": "a458d355-8c81-44e8-b3da-3421d2c8beea",
+            "width": 0
+        },
+        "5f4c09d3-82aa-425f-b20d-4d6356945f44": {
+            "from": "3364e9fa-46e6-4453-b79e-66a1e57c4bac",
+            "layer": 0,
+            "to": "ca56e0d6-a15d-4ed8-9fea-ab17aa0af793",
+            "width": 0
+        },
+        "669251f6-68eb-4466-87e1-b5d05446d204": {
+            "from": "5e3fb670-ade5-42ef-ace3-56fb38951ba8",
+            "layer": 0,
+            "to": "81098d67-14de-40a9-9b3e-a0f19dd406d6",
+            "width": 0
+        },
+        "8b87df50-f0dc-4ecd-baeb-9744fbfedd11": {
+            "from": "13f4d600-df5b-4aab-b08e-06648be94fe6",
+            "layer": 0,
+            "to": "3da3743d-12d6-4aa6-8a7d-61cfa7cf46c9",
+            "width": 0
+        }
+    },
+    "name": "ADS101x",
+    "pins": {
+        "007b1986-ef61-4c37-a4ad-cce2413b5f62": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                35000000,
+                5000000
+            ]
+        },
+        "047ed370-f9fd-451e-9d05-50d44daaba30": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                35000000,
+                -5000000
+            ]
+        },
+        "085aeeaf-6746-422d-91bc-256b2b9a3997": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -35000000,
+                -5000000
+            ]
+        },
+        "190fcf2e-cd47-431c-8c2f-c862bfcf4510": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -35000000,
+                -2500000
+            ]
+        },
+        "5942f84d-3a88-46ea-8085-1c42dc092ed1": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -35000000,
+                5000000
+            ]
+        },
+        "8a43adea-296d-4851-8ba5-fc684a57244e": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                35000000,
+                -2500000
+            ]
+        },
+        "8d22aa83-fcb0-4427-b5bc-969a255747f4": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                35000000,
+                2500000
+            ]
+        },
+        "cc0095f2-e203-44e4-9ae5-fe2774480579": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                35000000,
+                0
+            ]
+        },
+        "cebce729-e05b-485c-94a6-886b38a64db2": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -35000000,
+                0
+            ]
+        },
+        "d726824b-5ea5-4478-935d-031798694406": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 7500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -35000000,
+                2500000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {},
+    "texts": {
+        "2df9f405-55e5-438b-ac62-a469ed8f7821": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -27500000,
+                    11250000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        },
+        "7d0ad300-b9fb-44ca-bf23-bb03e91d3099": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -27500000,
+                    -11250000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "a3d29515-8422-4d40-83d1-fbd099c34d1e",
+    "uuid": "e4eac32d-7799-4886-8d7c-ddac8924c70a"
+}

--- a/units/ic/adc/ti/ADS101x.json
+++ b/units/ic/adc/ti/ADS101x.json
@@ -1,0 +1,68 @@
+{
+    "manufacturer": "Texas Instruments",
+    "name": "ADS101x",
+    "pins": {
+        "007b1986-ef61-4c37-a4ad-cce2413b5f62": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "SCL",
+            "swap_group": 0
+        },
+        "047ed370-f9fd-451e-9d05-50d44daaba30": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "AIN2",
+            "swap_group": 0
+        },
+        "085aeeaf-6746-422d-91bc-256b2b9a3997": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "AIN1",
+            "swap_group": 0
+        },
+        "190fcf2e-cd47-431c-8c2f-c862bfcf4510": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "AIN0",
+            "swap_group": 0
+        },
+        "5942f84d-3a88-46ea-8085-1c42dc092ed1": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "ADDR",
+            "swap_group": 0
+        },
+        "8a43adea-296d-4851-8ba5-fc684a57244e": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "AIN3",
+            "swap_group": 0
+        },
+        "8d22aa83-fcb0-4427-b5bc-969a255747f4": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "SDA",
+            "swap_group": 0
+        },
+        "cc0095f2-e203-44e4-9ae5-fe2774480579": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "VDD",
+            "swap_group": 0
+        },
+        "cebce729-e05b-485c-94a6-886b38a64db2": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "GND",
+            "swap_group": 0
+        },
+        "d726824b-5ea5-4478-935d-031798694406": {
+            "direction": "output",
+            "names": [],
+            "primary_name": "ALERT/RDY",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "a3d29515-8422-4d40-83d1-fbd099c34d1e"
+}


### PR DESCRIPTION
Adds the TI ADS101x family of 12-bit delta-sigma ADCs in the VSSOP (DGS) package.These share a datasheet: https://www.ti.com/product/ADS1015

The footprint and symbol were exported from TI in KiCad format, imported, and touched up to pass checks. The 3D model was exported from TI as a STEP file, imported, and manually aligned.

I haven't made a board with this yet, but one is in the works, so I should be able to report back with test results once that's done.