### PR TITLE
add mosfet DMP610DL

### DIFF
--- a/parts/transistor/pmos/DMP3099L.json
+++ b/parts/transistor/pmos/DMP3099L.json
@@ -3,6 +3,7 @@
         false,
         "DMP3099L"
     ],
+    "base": "03b1c077-db19-40a1-9a65-208053aff665",
     "datasheet": [
         false,
         "https://www.diodes.com/assets/Datasheets/DMP3099L.pdf"
@@ -11,9 +12,8 @@
         false,
         "P-channel MOSFET, -30V, -3.8A, 65mΩ"
     ],
-    "entity": "f1cafe55-ca30-4a2f-9c9e-ae06f9ea7859",
     "inherit_model": true,
-    "inherit_tags": false,
+    "inherit_tags": true,
     "manufacturer": [
         false,
         "Diodes Inc."
@@ -23,28 +23,8 @@
         "00083c25-3e2b-466f-877f-631779bfccda": "DMP3099L-13",
         "2da6e1c4-50f4-4cc4-bd00-d7170daad70b": "DMP3099L-7"
     },
-    "package": "a37e4931-af72-4de0-b4e4-0357747ba44d",
-    "pad_map": {
-        "531c3759-a1b6-40c6-9474-5554dc94bcec": {
-            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
-            "pin": "4887ef47-94f0-4fd1-b552-c424bd37a3e7"
-        },
-        "9fe9b6c3-f887-4523-976a-6aa050235658": {
-            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
-            "pin": "074c3718-08fd-4f94-88fc-2bb43174b245"
-        },
-        "be802fd1-5220-4258-a11f-c1529e6187e0": {
-            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
-            "pin": "eb63ac9a-5d7e-42e2-92ea-a140a97f47d0"
-        }
-    },
     "parametric": {},
-    "tags": [
-        "mosfet",
-        "p-channel",
-        "smd",
-        "transistor"
-    ],
+    "tags": [],
     "type": "part",
     "uuid": "cc5ebbec-0032-49f3-92bd-37853ebe5a2d",
     "value": [

--- a/parts/transistor/pmos/DMP610DL.json
+++ b/parts/transistor/pmos/DMP610DL.json
@@ -3,7 +3,7 @@
         false,
         "DMP610DL"
     ],
-    "base": "cc5ebbec-0032-49f3-92bd-37853ebe5a2d",
+    "base": "03b1c077-db19-40a1-9a65-208053aff665",
     "datasheet": [
         false,
         "https://www.diodes.com/assets/Datasheets/DMP610DL.pdf"
@@ -15,7 +15,7 @@
     "inherit_model": true,
     "inherit_tags": true,
     "manufacturer": [
-        true,
+        false,
         "Diodes Inc."
     ],
     "model": "1ebac498-5423-42dc-90a6-7ad333585f6a",
@@ -28,7 +28,7 @@
     "type": "part",
     "uuid": "b53c4477-a882-44ed-b19d-9ced4d6f47ef",
     "value": [
-        true,
-        "DMP3099L"
+        false,
+        ""
     ]
 }

--- a/parts/transistor/pmos/DMP610DL.json
+++ b/parts/transistor/pmos/DMP610DL.json
@@ -1,0 +1,34 @@
+{
+    "MPN": [
+        false,
+        "DMP610DL"
+    ],
+    "base": "cc5ebbec-0032-49f3-92bd-37853ebe5a2d",
+    "datasheet": [
+        false,
+        "https://www.diodes.com/assets/Datasheets/DMP610DL.pdf"
+    ],
+    "description": [
+        false,
+        "P-channel MOSFET, -60V, -180mA, 10Ω"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        true,
+        "Diodes Inc."
+    ],
+    "model": "1ebac498-5423-42dc-90a6-7ad333585f6a",
+    "orderable_MPNs": {
+        "5d9ccd80-c439-4700-8d7c-83441a071cc9": "DMP610DL-13",
+        "dc83200b-0370-4321-bb93-dcd244b79ce3": "DMP610DL-7"
+    },
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "b53c4477-a882-44ed-b19d-9ced4d6f47ef",
+    "value": [
+        true,
+        "DMP3099L"
+    ]
+}

--- a/parts/transistor/pmos/base-sot-23.json
+++ b/parts/transistor/pmos/base-sot-23.json
@@ -1,0 +1,56 @@
+{
+    "MPN": [
+        false,
+        "base sot-23 P-channel MOSFET"
+    ],
+    "datasheet": [
+        false,
+        ""
+    ],
+    "description": [
+        false,
+        "base P-channel MOSFET, SOT-23"
+    ],
+    "entity": "f1cafe55-ca30-4a2f-9c9e-ae06f9ea7859",
+    "flags": {
+        "base_part": "set",
+        "exclude_bom": "clear",
+        "exclude_pnp": "clear"
+    },
+    "inherit_model": true,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        ""
+    ],
+    "model": "1ebac498-5423-42dc-90a6-7ad333585f6a",
+    "package": "a37e4931-af72-4de0-b4e4-0357747ba44d",
+    "pad_map": {
+        "531c3759-a1b6-40c6-9474-5554dc94bcec": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "4887ef47-94f0-4fd1-b552-c424bd37a3e7"
+        },
+        "9fe9b6c3-f887-4523-976a-6aa050235658": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "074c3718-08fd-4f94-88fc-2bb43174b245"
+        },
+        "be802fd1-5220-4258-a11f-c1529e6187e0": {
+            "gate": "6dce85e8-6b70-44ac-8ae8-d17152c3707a",
+            "pin": "eb63ac9a-5d7e-42e2-92ea-a140a97f47d0"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "mosfet",
+        "p-channel",
+        "smd",
+        "transistor"
+    ],
+    "type": "part",
+    "uuid": "03b1c077-db19-40a1-9a65-208053aff665",
+    "value": [
+        false,
+        ""
+    ],
+    "version": 1
+}


### PR DESCRIPTION
Bot!
As always I have a question.
Is it right to inherit from other similar part which is not a base part?
Here I made DMP610DL mosfet which inherits from DMP3099L. These have much in common except electrical characteristics.
![image](https://github.com/horizon-eda/horizon-pool/assets/46829407/4f32a39b-4b06-4425-9bb4-4c6d10d81ea1)
