### PR TITLE
add analog 8ch mux/demux

### DIFF
--- a/entities/logic/single-mux-demux-8ch-en.json
+++ b/entities/logic/single-mux-demux-8ch-en.json
@@ -1,0 +1,24 @@
+{
+    "gates": {
+        "7b5a55c1-0b5c-4833-8d9a-82fbf512ed6f": {
+            "name": "Power",
+            "suffix": "P",
+            "swap_group": 0,
+            "unit": "181063c3-1fb2-46c5-9543-7283fadfc117"
+        },
+        "a20ef812-8b40-4b0d-ad07-6d20074342ad": {
+            "name": "A",
+            "suffix": "A",
+            "swap_group": 0,
+            "unit": "0b8ec7e0-aebb-494c-b569-bf6cfd2ead30"
+        }
+    },
+    "manufacturer": "",
+    "name": "Single MUX/DEMUX 8ch with EN",
+    "prefix": "U",
+    "tags": [
+        "logic"
+    ],
+    "type": "entity",
+    "uuid": "74a82bee-d6cb-42ad-a736-34fce97e61b1"
+}

--- a/parts/ic/logic/base-tssop-16-mux-demux-8ch-en.json
+++ b/parts/ic/logic/base-tssop-16-mux-demux-8ch-en.json
@@ -1,0 +1,105 @@
+{
+    "MPN": [
+        false,
+        "base TSSOP-16 MUX/DEMUX 8ch with EN"
+    ],
+    "datasheet": [
+        false,
+        ""
+    ],
+    "description": [
+        false,
+        ""
+    ],
+    "entity": "74a82bee-d6cb-42ad-a736-34fce97e61b1",
+    "flags": {
+        "base_part": "set",
+        "exclude_bom": "clear",
+        "exclude_pnp": "clear"
+    },
+    "inherit_model": true,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        ""
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "package": "c1ffc1fa-ee70-46f0-8869-52c7518dfa1e",
+    "pad_map": {
+        "1d4bf8f0-bd77-4bd2-96c1-065e04f5aac4": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "fc7168c1-bbeb-4288-baa4-dfe468194f31"
+        },
+        "1d84de48-953b-4cfa-b28e-ee0fea9b2b9d": {
+            "gate": "7b5a55c1-0b5c-4833-8d9a-82fbf512ed6f",
+            "pin": "361ab549-44ca-4a8f-8baa-f84b129bd353"
+        },
+        "255d43f3-7c29-4fe7-8eb2-ffb740798427": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "cee4e4fc-58da-423a-bcae-27b0f018de2f"
+        },
+        "37ec7a5b-e203-47ff-a421-ba9b1e9101cd": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "80031ce9-86c8-47d2-abed-e701d6737777"
+        },
+        "3f62c908-e6a5-4300-a708-aeae5b4aab80": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "81dd7f88-ea05-4779-9585-da50a2e8bcb0"
+        },
+        "446b81e0-3afc-48b0-9ab5-8babdc6deb6a": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "fe2e6af6-be57-4499-b3b5-3ebcbfa52397"
+        },
+        "53285fec-3ebc-4f27-aa6f-a3f7ac1bd7f8": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "fa9ff207-3242-4afb-8d27-550cf2189f5a"
+        },
+        "54b3d96f-e226-49cb-81cf-4d76ce3c1480": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "b525a88d-a0e3-4c86-b2e2-0aa6aeef7fad"
+        },
+        "5b77f19a-59d1-40ec-bf4a-5328ae9dbffd": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "54bc5e17-49b8-4d7b-9bdc-6ba19dbd4714"
+        },
+        "9eb190ff-ce24-41cb-a25b-15cf629e394b": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "3f645db8-94bb-463e-90f6-fc69048c4f7f"
+        },
+        "abef0b7e-fd16-48d3-880c-5a80ad0ac6f8": {
+            "gate": "7b5a55c1-0b5c-4833-8d9a-82fbf512ed6f",
+            "pin": "31ff91ed-5f99-464f-b1b6-1480fb83fd16"
+        },
+        "b50db897-985a-4f47-9c46-82f1db5fdd44": {
+            "gate": "7b5a55c1-0b5c-4833-8d9a-82fbf512ed6f",
+            "pin": "21a8f74f-652c-41e7-87cd-3734cae0ee52"
+        },
+        "ba2e99cd-25de-4c2c-86f6-14b8557d0475": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "6f97fcb6-f591-459e-acd9-b80396c01a99"
+        },
+        "d136be23-6be5-427c-ad57-7de76bc93940": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "ada8f863-e2bb-45ed-a1f6-e140de0e0546"
+        },
+        "f1d744cf-840d-424d-98a8-e4af5e78c8ba": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "a70fea83-0843-4b77-838e-3d4e58edb806"
+        },
+        "ffb28a61-8fd0-4db3-a62b-e701c3d4962c": {
+            "gate": "a20ef812-8b40-4b0d-ad07-6d20074342ad",
+            "pin": "184f8d1e-e072-4aef-9506-0318707173bb"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "logic"
+    ],
+    "type": "part",
+    "uuid": "e79b98f9-0e89-4f60-9176-d9256780264c",
+    "value": [
+        false,
+        ""
+    ],
+    "version": 1
+}

--- a/parts/ic/logic/nexperia/74HC4051PW.json
+++ b/parts/ic/logic/nexperia/74HC4051PW.json
@@ -1,0 +1,30 @@
+{
+    "MPN": [
+        false,
+        "74HC4051PW"
+    ],
+    "base": "e79b98f9-0e89-4f60-9176-d9256780264c",
+    "datasheet": [
+        false,
+        "https://assets.nexperia.com/documents/data-sheet/74HC_HCT4051.pdf"
+    ],
+    "description": [
+        false,
+        "8-channel analog multiplexer/demultiplexer"
+    ],
+    "inherit_model": true,
+    "inherit_tags": true,
+    "manufacturer": [
+        false,
+        "Nexperia"
+    ],
+    "model": "00000000-0000-0000-0000-000000000000",
+    "parametric": {},
+    "tags": [],
+    "type": "part",
+    "uuid": "b7782763-8fc1-4155-97a5-3b8250815fa8",
+    "value": [
+        false,
+        ""
+    ]
+}

--- a/symbols/common/power-dual-gnd.json
+++ b/symbols/common/power-dual-gnd.json
@@ -1,0 +1,116 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "017220bc-e886-4d5b-96c3-2d59e2b4e63f": {
+            "position": [
+                2500000,
+                -3750000
+            ]
+        },
+        "4de94f35-554b-45a6-83f5-20fcc04fdc10": {
+            "position": [
+                -2500000,
+                3750000
+            ]
+        },
+        "ac75b495-ad48-4c9f-a9ea-9f9c77476f2e": {
+            "position": [
+                2500000,
+                3750000
+            ]
+        },
+        "af2c9c6d-146e-445f-83ae-20a991063e75": {
+            "position": [
+                -2500000,
+                -3750000
+            ]
+        }
+    },
+    "lines": {
+        "44fa9da3-91d6-4fdc-8c62-93c570799292": {
+            "from": "4de94f35-554b-45a6-83f5-20fcc04fdc10",
+            "layer": 0,
+            "to": "ac75b495-ad48-4c9f-a9ea-9f9c77476f2e",
+            "width": 0
+        },
+        "83d11958-932a-4bd6-95a6-8f101aa6ec43": {
+            "from": "ac75b495-ad48-4c9f-a9ea-9f9c77476f2e",
+            "layer": 0,
+            "to": "017220bc-e886-4d5b-96c3-2d59e2b4e63f",
+            "width": 0
+        },
+        "8be86873-28ad-410f-b45b-4e82ca176d9a": {
+            "from": "017220bc-e886-4d5b-96c3-2d59e2b4e63f",
+            "layer": 0,
+            "to": "af2c9c6d-146e-445f-83ae-20a991063e75",
+            "width": 0
+        },
+        "e8bdaf48-f93f-4cad-a20c-ae59add02419": {
+            "from": "af2c9c6d-146e-445f-83ae-20a991063e75",
+            "layer": 0,
+            "to": "4de94f35-554b-45a6-83f5-20fcc04fdc10",
+            "width": 0
+        }
+    },
+    "name": "Dual power with GND",
+    "pins": {
+        "21a8f74f-652c-41e7-87cd-3734cae0ee52": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                0,
+                6250000
+            ]
+        },
+        "31ff91ed-5f99-464f-b1b6-1480fb83fd16": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                5000000,
+                0
+            ]
+        },
+        "361ab549-44ca-4a8f-8baa-f84b129bd353": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "perpendicular",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                0,
+                -6250000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {},
+    "texts": {},
+    "type": "symbol",
+    "unit": "181063c3-1fb2-46c5-9543-7283fadfc117",
+    "uuid": "7b7f9caa-63dd-40db-b30d-a5c11fde2555"
+}

--- a/symbols/logic/mux-demux-8ch-en.json
+++ b/symbols/logic/mux-demux-8ch-en.json
@@ -1,0 +1,286 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "0e628651-d471-4bce-a013-b132662031ef": {
+            "position": [
+                6250000,
+                -6250000
+            ]
+        },
+        "f3f5374d-5f9a-423a-aeec-1b1603176888": {
+            "position": [
+                -6250000,
+                11250000
+            ]
+        },
+        "fa1fdf64-4f6e-4cce-882b-dc99d0987dc5": {
+            "position": [
+                -6250000,
+                -11250000
+            ]
+        },
+        "faf531d3-0b9b-4454-b74b-4d19ea9c82cf": {
+            "position": [
+                6250000,
+                6250000
+            ]
+        }
+    },
+    "lines": {
+        "678e7f88-2060-4c0d-a876-415046c02a59": {
+            "from": "f3f5374d-5f9a-423a-aeec-1b1603176888",
+            "layer": 0,
+            "to": "fa1fdf64-4f6e-4cce-882b-dc99d0987dc5",
+            "width": 0
+        },
+        "b50cfe37-b902-4945-9290-94e029191473": {
+            "from": "fa1fdf64-4f6e-4cce-882b-dc99d0987dc5",
+            "layer": 0,
+            "to": "0e628651-d471-4bce-a013-b132662031ef",
+            "width": 0
+        },
+        "e17e31d0-b367-4314-9a8c-2b7d3213c724": {
+            "from": "faf531d3-0b9b-4454-b74b-4d19ea9c82cf",
+            "layer": 0,
+            "to": "f3f5374d-5f9a-423a-aeec-1b1603176888",
+            "width": 0
+        },
+        "e1954e5c-db51-4916-9f6c-23ac176da55b": {
+            "from": "0e628651-d471-4bce-a013-b132662031ef",
+            "layer": 0,
+            "to": "faf531d3-0b9b-4454-b74b-4d19ea9c82cf",
+            "width": 0
+        }
+    },
+    "name": "MUX/DEMUX 8ch with EN",
+    "pins": {
+        "184f8d1e-e072-4aef-9506-0318707173bb": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                6250000
+            ]
+        },
+        "3f645db8-94bb-463e-90f6-fc69048c4f7f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                3750000
+            ]
+        },
+        "54bc5e17-49b8-4d7b-9bdc-6ba19dbd4714": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 4250000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "up",
+            "pad_visible": true,
+            "position": [
+                1250000,
+                12500000
+            ]
+        },
+        "6f97fcb6-f591-459e-acd9-b80396c01a99": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 5250000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                3750000,
+                -12500000
+            ]
+        },
+        "80031ce9-86c8-47d2-abed-e701d6737777": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 3250000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                -1250000,
+                -12500000
+            ]
+        },
+        "81dd7f88-ea05-4779-9585-da50a2e8bcb0": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                -8750000
+            ]
+        },
+        "a70fea83-0843-4b77-838e-3d4e58edb806": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                -3750000
+            ]
+        },
+        "ada8f863-e2bb-45ed-a1f6-e140de0e0546": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                8750000,
+                0
+            ]
+        },
+        "b525a88d-a0e3-4c86-b2e2-0aa6aeef7fad": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                -6250000
+            ]
+        },
+        "cee4e4fc-58da-423a-bcae-27b0f018de2f": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                1250000
+            ]
+        },
+        "fa9ff207-3242-4afb-8d27-550cf2189f5a": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 4250000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "down",
+            "pad_visible": true,
+            "position": [
+                1250000,
+                -12500000
+            ]
+        },
+        "fc7168c1-bbeb-4288-baa4-dfe468194f31": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                -1250000
+            ]
+        },
+        "fe2e6af6-be57-4499-b3b5-3ebcbfa52397": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -8750000,
+                8750000
+            ]
+        }
+    },
+    "polygons": {},
+    "text_placements": {},
+    "texts": {},
+    "type": "symbol",
+    "unit": "0b8ec7e0-aebb-494c-b569-bf6cfd2ead30",
+    "uuid": "414d27b3-ebf1-46af-95f2-1bda5186c43a"
+}

--- a/units/common/power-dual-gnd.json
+++ b/units/common/power-dual-gnd.json
@@ -1,0 +1,39 @@
+{
+    "manufacturer": "",
+    "name": "Dual power with GND",
+    "pins": {
+        "21a8f74f-652c-41e7-87cd-3734cae0ee52": {
+            "alt_names": {
+                "8d4ec200-be95-4623-b7d5-a3fbb4b93d1b": {
+                    "direction": "input",
+                    "name": "Vdd"
+                }
+            },
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vcc",
+            "swap_group": 0
+        },
+        "31ff91ed-5f99-464f-b1b6-1480fb83fd16": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "GND",
+            "swap_group": 0
+        },
+        "361ab549-44ca-4a8f-8baa-f84b129bd353": {
+            "alt_names": {
+                "65f9c69f-b57f-4656-8781-6db10f511956": {
+                    "direction": "input",
+                    "name": "Vss"
+                }
+            },
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vee",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "181063c3-1fb2-46c5-9543-7283fadfc117",
+    "version": 1
+}

--- a/units/logic/mux-demux-8ch-en.json
+++ b/units/logic/mux-demux-8ch-en.json
@@ -1,0 +1,86 @@
+{
+    "manufacturer": "",
+    "name": "Single-ended MUX/DEMUX 8ch with EN",
+    "pins": {
+        "184f8d1e-e072-4aef-9506-0318707173bb": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y1",
+            "swap_group": 0
+        },
+        "3f645db8-94bb-463e-90f6-fc69048c4f7f": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y2",
+            "swap_group": 0
+        },
+        "54bc5e17-49b8-4d7b-9bdc-6ba19dbd4714": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "~EN",
+            "swap_group": 0
+        },
+        "6f97fcb6-f591-459e-acd9-b80396c01a99": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "S2",
+            "swap_group": 0
+        },
+        "80031ce9-86c8-47d2-abed-e701d6737777": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "S0",
+            "swap_group": 0
+        },
+        "81dd7f88-ea05-4779-9585-da50a2e8bcb0": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y7",
+            "swap_group": 0
+        },
+        "a70fea83-0843-4b77-838e-3d4e58edb806": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y5",
+            "swap_group": 0
+        },
+        "ada8f863-e2bb-45ed-a1f6-e140de0e0546": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Z",
+            "swap_group": 0
+        },
+        "b525a88d-a0e3-4c86-b2e2-0aa6aeef7fad": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y6",
+            "swap_group": 0
+        },
+        "cee4e4fc-58da-423a-bcae-27b0f018de2f": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y3",
+            "swap_group": 0
+        },
+        "fa9ff207-3242-4afb-8d27-550cf2189f5a": {
+            "direction": "input",
+            "names": [],
+            "primary_name": "S1",
+            "swap_group": 0
+        },
+        "fc7168c1-bbeb-4288-baa4-dfe468194f31": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y4",
+            "swap_group": 0
+        },
+        "fe2e6af6-be57-4499-b3b5-3ebcbfa52397": {
+            "direction": "bidirectional",
+            "names": [],
+            "primary_name": "Y0",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "0b8ec7e0-aebb-494c-b569-bf6cfd2ead30"
+}


### PR DESCRIPTION
As always bot will fail because base part doesn't have description.
I'm not sure about multiplexer's I/O naming. I made base part according Nexperia datasheet where channels named Y0, Y1,..., Y7, and output (let's call it so) named Z. On internet I found many examples with different namings. Our logic components (AND, OR, XOR.....) already in pool uses letters A, B, C, .... for channels and 'Y' for output. Maybe I should continue that way.... Every manufacturer uses their own naming for multiplexer's I/Os...