### PR TITLE
Add Analog Devices ADR4525BRZ (SOIC-8)

### DIFF
--- a/entities/ADR4525BRZ-R7.json
+++ b/entities/ADR4525BRZ-R7.json
@@ -1,0 +1,19 @@
+{
+    "gates": {
+        "6edeb791-4930-424c-8348-c3049fddffb0": {
+            "name": "Main",
+            "suffix": "",
+            "swap_group": 0,
+            "unit": "6acc1080-d60c-4715-b318-944ca49b64c7"
+        }
+    },
+    "manufacturer": "Analog Devices",
+    "name": "ADR4525BRZ-R7",
+    "prefix": "U",
+    "tags": [
+        "reference",
+        "regulator"
+    ],
+    "type": "entity",
+    "uuid": "53e86b8e-a8ad-4add-999f-917e18b2d4b0"
+}

--- a/parts/ADR4525BRZ-R7.json
+++ b/parts/ADR4525BRZ-R7.json
@@ -1,0 +1,72 @@
+{
+    "MPN": [
+        false,
+        "ADR4525BRZ-R7"
+    ],
+    "datasheet": [
+        false,
+        "https://www.analog.com/media/en/technical-documentation/data-sheets/adr4520_4525_4530_4533_4540_4550.pdf"
+    ],
+    "description": [
+        false,
+        "2.5V ±0.02% 3V~15V 10mA Fixed SOIC-8 Voltage References"
+    ],
+    "entity": "53e86b8e-a8ad-4add-999f-917e18b2d4b0",
+    "inherit_model": true,
+    "inherit_tags": false,
+    "manufacturer": [
+        false,
+        "Analog Devices"
+    ],
+    "model": "b99785a3-c0da-4658-969d-6287cec3be05",
+    "orderable_MPNs": {
+        "7cb7f727-4130-4a61-838a-3f020399aad2": "ADR4525BRZ-R7"
+    },
+    "package": "0932e22e-0cf7-46dc-b09c-4cc761a67608",
+    "pad_map": {
+        "17341892-a120-44e2-97ea-6e4f8e3d7da5": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "54b6c7e3-9f75-416f-9809-6b742e4814b7"
+        },
+        "29f18ab8-6cea-44fc-9bf5-4fb888f5245b": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "29dc2501-28a2-41bb-84c6-198878882fab"
+        },
+        "3d725e25-0d60-46cb-a21f-82462d3ce156": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "6f756c3a-3ae2-4862-bfaa-e531af969e17"
+        },
+        "51d7c05f-acae-46d5-9c26-2ea9d17bf7a8": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "11df7926-d025-49a0-a996-ca8c65a7a2f8"
+        },
+        "68b17b6f-ab52-4c2b-9389-c36d3c06eeef": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "6d2dd35b-0ed5-47c0-b22e-54d481be418c"
+        },
+        "6f82c7c4-9578-4cb0-a92c-8b09534d5dc9": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "2b8539c6-7855-4994-8239-cb66c46ff1b0"
+        },
+        "82d773fb-4473-4bd9-a879-a6ca2756055c": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "5ce3faff-dd04-4ba1-b278-74d5d164b47a"
+        },
+        "b9ad4acf-f78d-438d-8b7b-e83ee0f9cc19": {
+            "gate": "6edeb791-4930-424c-8348-c3049fddffb0",
+            "pin": "444d43d5-0f62-4680-b703-2f5a671b4b76"
+        }
+    },
+    "parametric": {},
+    "tags": [
+        "reference",
+        "regulator",
+        "vref"
+    ],
+    "type": "part",
+    "uuid": "31eef3cb-96ee-4313-96ee-7a1920f50eb1",
+    "value": [
+        false,
+        ""
+    ]
+}

--- a/symbols/ADR4525xRZ.json
+++ b/symbols/ADR4525xRZ.json
@@ -1,0 +1,267 @@
+{
+    "arcs": {},
+    "can_expand": false,
+    "junctions": {
+        "20b86bca-e9a9-4969-b197-7dac837aa545": {
+            "position": [
+                7500000,
+                6250000
+            ]
+        },
+        "213b4d2d-0a49-4150-8dad-6ca069466b18": {
+            "position": [
+                -7500000,
+                -6250000
+            ]
+        },
+        "854e5680-4c61-4869-bae5-703a22034a4f": {
+            "position": [
+                7500000,
+                -6250000
+            ]
+        },
+        "e4de26d1-6874-4d4a-8f7c-b0af3d5acac2": {
+            "position": [
+                -7500000,
+                6250000
+            ]
+        }
+    },
+    "lines": {
+        "34f5e43d-3446-4885-a601-aa9da1a7d289": {
+            "from": "854e5680-4c61-4869-bae5-703a22034a4f",
+            "layer": 0,
+            "to": "213b4d2d-0a49-4150-8dad-6ca069466b18",
+            "width": 0
+        },
+        "49777d0c-817d-4afd-bf9e-e16e5c5cb831": {
+            "from": "e4de26d1-6874-4d4a-8f7c-b0af3d5acac2",
+            "layer": 0,
+            "to": "20b86bca-e9a9-4969-b197-7dac837aa545",
+            "width": 0
+        },
+        "a39c26fd-5eea-4860-bfe4-9dd53080bfab": {
+            "from": "213b4d2d-0a49-4150-8dad-6ca069466b18",
+            "layer": 0,
+            "to": "e4de26d1-6874-4d4a-8f7c-b0af3d5acac2",
+            "width": 0
+        },
+        "c3ef0b3b-2a18-4591-bef7-6066a9d8e461": {
+            "from": "20b86bca-e9a9-4969-b197-7dac837aa545",
+            "layer": 0,
+            "to": "854e5680-4c61-4869-bae5-703a22034a4f",
+            "width": 0
+        }
+    },
+    "name": "ADR4525xRZ",
+    "pins": {
+        "11df7926-d025-49a0-a996-ca8c65a7a2f8": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -10000000,
+                3750000
+            ]
+        },
+        "29dc2501-28a2-41bb-84c6-198878882fab": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -10000000,
+                -3750000
+            ]
+        },
+        "2b8539c6-7855-4994-8239-cb66c46ff1b0": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                10000000,
+                1250000
+            ]
+        },
+        "444d43d5-0f62-4680-b703-2f5a671b4b76": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                10000000,
+                3750000
+            ]
+        },
+        "54b6c7e3-9f75-416f-9809-6b742e4814b7": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -10000000,
+                1250000
+            ]
+        },
+        "5ce3faff-dd04-4ba1-b278-74d5d164b47a": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                10000000,
+                -1250000
+            ]
+        },
+        "6d2dd35b-0ed5-47c0-b22e-54d481be418c": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "left",
+            "pad_visible": true,
+            "position": [
+                -10000000,
+                -1250000
+            ]
+        },
+        "6f756c3a-3ae2-4862-bfaa-e531af969e17": {
+            "decoration": {
+                "clock": false,
+                "dot": false,
+                "driver": "default",
+                "schmitt": false
+            },
+            "length": 2500000,
+            "name_orientation": "in_line",
+            "name_visible": true,
+            "orientation": "right",
+            "pad_visible": true,
+            "position": [
+                10000000,
+                -3750000
+            ]
+        }
+    },
+    "polygons": {
+        "6a3cfe37-571f-4bfe-976a-97c7447161c2": {
+            "layer": 0,
+            "parameter_class": "",
+            "vertices": [
+                {
+                    "arc_center": [
+                        0,
+                        0
+                    ],
+                    "arc_reverse": false,
+                    "position": [
+                        -7325000,
+                        6250000
+                    ],
+                    "type": "line"
+                },
+                {
+                    "arc_center": [
+                        -7500000,
+                        6250000
+                    ],
+                    "arc_reverse": true,
+                    "position": [
+                        -7325000,
+                        6250000
+                    ],
+                    "type": "arc"
+                }
+            ]
+        }
+    },
+    "text_placements": {},
+    "texts": {
+        "22aa76db-596b-4e67-a730-4de913cc4612": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5000000,
+                    -7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$VALUE",
+            "width": 0
+        },
+        "9061c1c6-ab67-4b73-bcec-3f673ffbb157": {
+            "font": "simplex",
+            "from_smash": false,
+            "layer": 0,
+            "origin": "center",
+            "placement": {
+                "angle": 0,
+                "mirror": false,
+                "shift": [
+                    -5000000,
+                    7500000
+                ]
+            },
+            "size": 1500000,
+            "text": "$REFDES",
+            "width": 0
+        }
+    },
+    "type": "symbol",
+    "unit": "6acc1080-d60c-4715-b318-944ca49b64c7",
+    "uuid": "b8b302d5-752e-4fa3-a816-642ed009014d"
+}

--- a/units/ADR4525xRZ.json
+++ b/units/ADR4525xRZ.json
@@ -1,0 +1,87 @@
+{
+    "manufacturer": "Analog Devices",
+    "name": "ADR4525xRZ",
+    "pins": {
+        "11df7926-d025-49a0-a996-ca8c65a7a2f8": {
+            "alt_names": {
+                "8eafebba-63b0-4861-9846-b862f03f72d4": {
+                    "direction": "passive",
+                    "name": "Not Internally Connected"
+                }
+            },
+            "direction": "passive",
+            "names": [],
+            "primary_name": "NIC",
+            "swap_group": 0
+        },
+        "29dc2501-28a2-41bb-84c6-198878882fab": {
+            "direction": "passive",
+            "names": [],
+            "primary_name": "GND",
+            "swap_group": 0
+        },
+        "2b8539c6-7855-4994-8239-cb66c46ff1b0": {
+            "alt_names": {
+                "73a2edfc-d9fc-41e5-a624-27136d10f889": {
+                    "direction": "passive",
+                    "name": "Not internally connected"
+                }
+            },
+            "direction": "passive",
+            "names": [],
+            "primary_name": "NIC2",
+            "swap_group": 0
+        },
+        "444d43d5-0f62-4680-b703-2f5a671b4b76": {
+            "alt_names": {
+                "889c3a61-50ea-406f-bd31-2eab709ba9bd": {
+                    "direction": "passive",
+                    "name": "Do not connect"
+                }
+            },
+            "direction": "passive",
+            "names": [],
+            "primary_name": "DNC",
+            "swap_group": 0
+        },
+        "54b6c7e3-9f75-416f-9809-6b742e4814b7": {
+            "direction": "power_input",
+            "names": [],
+            "primary_name": "Vin",
+            "swap_group": 0
+        },
+        "5ce3faff-dd04-4ba1-b278-74d5d164b47a": {
+            "direction": "power_output",
+            "names": [],
+            "primary_name": "Vout",
+            "swap_group": 0
+        },
+        "6d2dd35b-0ed5-47c0-b22e-54d481be418c": {
+            "alt_names": {
+                "192f6763-de02-4818-8c57-1f7eafb1eea4": {
+                    "direction": "passive",
+                    "name": "Not internally connected"
+                }
+            },
+            "direction": "passive",
+            "names": [],
+            "primary_name": "NIC1",
+            "swap_group": 0
+        },
+        "6f756c3a-3ae2-4862-bfaa-e531af969e17": {
+            "alt_names": {
+                "889c3a61-50ea-406f-bd31-2eab709ba9bd": {
+                    "direction": "passive",
+                    "name": "Not internally connected"
+                }
+            },
+            "direction": "passive",
+            "names": [],
+            "primary_name": "NIC3",
+            "swap_group": 0
+        }
+    },
+    "type": "unit",
+    "uuid": "6acc1080-d60c-4715-b318-944ca49b64c7",
+    "version": 1
+}


### PR DESCRIPTION
Add Analog Devices ADR4525xRZ 2.5V precision voltage reference. Part is created for the BRZ version, B grade has a tempco of 2 ppm/C and a temperature range of -40 to 125 C. 

SOIC-8 package (RZ) only in this release, does not include the LCC version of this chip. Both parts have different pinouts anyway. 

Datasheet link: https://www.analog.com/media/en/technical-documentation/data-sheets/adr4520_4525_4530_4533_4540_4550.pdf